### PR TITLE
feat: push 触发自动发布 npm（替代外部轮询）

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish to npm
+
+# 事件驱动发布：main 分支有新提交即自动发布（不再需要外部定时轮询）
+# 版本管理：不自动递增，发布版本号 = 当前 package.json 的 version 字段
+# 发版流程：手动修改 version → push → 本 workflow 自动发布
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# 防止连续 push 导致并发发布冲突
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      # 兼容 OIDC 发布：npm 账户配置了 trusted publishing 时可免 NPM_TOKEN
+      # （清理 .npmrc 中残留的 _authToken，让 npm 走 OIDC 换取临时凭证）
+      - name: Clean .npmrc for OIDC
+        run: |
+          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            echo "Stripping _authToken from .npmrc for OIDC..."
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+          fi
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      # 当前版本是否已发布过（避免重复 push 同一版本时发布失败炸掉 workflow）
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/dsh-whale-widget/${VERSION}")
+          if [ "$CODE" = "200" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "版本 ${VERSION} 已存在于 npm，跳过发布"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "版本 ${VERSION} 未发布，开始发布"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.exists == 'false'
+        run: npm publish --access public --registry https://registry.npmjs.org --provenance=false
+        env:
+          # 可选：若在仓库设置了 NPM_TOKEN secret 则用它；未设置时自动走 OIDC
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-whale-widget",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "DSH Web 界面右下角的 DeepSeek 余额小鲸鱼挂件（含今日已用、峰谷定价、随机台词与音效）",
   "keywords": [
     "dsh",


### PR DESCRIPTION
## 背景

此前 npm 发布依赖外部桥接仓库（under-the-ocean/auto-publish-whale）每 2 小时轮询一次。本 PR 将发布逻辑直接内建到本仓库：**main 分支有 push 即自动发布**，零延迟、无需外部依赖。

## 改动内容

- **新增 `.github/workflows/publish.yml`**：push 到 main 自动发布 npm（`workflow_dispatch` 手动触发兜底）
- **package.json**：`0.2.0` → `0.2.2`（跳过已发布的 0.2.1，保证合并后首次发布即可成功）

## workflow 设计

- **版本管理**：不自动递增，发布版本 = 当前 `package.json` 的 version 字段，由仓库维护者手动控制
- **防重复发布**：发布前查询 npm registry，版本已存在则自动跳过（只改代码不 bump 版本时推多次也不会炸）
- **免 token 发布**：支持 npm **OIDC trusted publishing**（`id-token: write`，自动清理 .npmrc 残留 token）；也可用 `NPM_TOKEN` secret
- **并发保护**：`concurrency` 防止连续 push 撞车

## 合并前需要配置（二选一）

1. **推荐**：npm 账户（under_ocean）→ Access Tokens → 添加 Trusted Publishing，信任本仓库 `MeteorNOX/DeepSeek-Balance-Whale-Widget`（main 分支）
2. 或在本仓库 Settings → Secrets 添加 `NPM_TOKEN`

## 合并后

- 发版流程：手动改 `version` → push → 自动发布
- 旧桥接仓库 auto-publish-whale 可弃用