### PR TITLE
fix: 升级 npm 以支持 Trusted Publishing (OIDC) 发布

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,10 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
+      # 必须：npm >= 11.5.1 才支持 Trusted Publishing (OIDC) 自动交换；npm 10.x 会直接 ENEEDAUTH
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       # 兼容 OIDC 发布：npm 账户配置了 trusted publishing 时可免 NPM_TOKEN
       # （清理 .npmrc 中残留的 _authToken，让 npm 走 OIDC 换取临时凭证）
       - name: Clean .npmrc for OIDC


### PR DESCRIPTION
## 问题

合并的 `publish.yml` 在首次运行时 11 秒失败：

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

根因（已查证 npm 官方文档 docs.npmjs.com/trusted-publishers）：**npm CLI ≥ 11.5.1 才支持 Trusted Publishing (OIDC) 自动交换**，而运行环境是 npm 10.9.8，**不尝试 OIDC、直接报 ENEEDAUTH**。

## 修复

在 `Setup Node.js` 后补回 `npm install -g npm@latest`（与已验证成功发布 0.2.1 的桥接链路一致），确保 npm ≥ 11.5.1。

## 合并后还需配置（npm 账户侧）

登录 npmjs.com → 包 `dsh-whale-widget` → Settings → **Trusted Publisher**（或 Access Tokens → Add New Token → GitHub Actions）：

- GitHub Organization/User：`MeteorNOX`
- Repository：`DeepSeek-Balance-Whale-Widget`
- Workflow filename：`publish.yml`（可选）

配置完成后，push 到 main 即自动发布。