### PR TITLE
fix: 修复单行随机台词后重开气泡「今日已用」消失

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -422,8 +422,10 @@ function restoreBubbleLines() {
   labelEl.className = 'dshwv-label'
   labelEl.textContent = 'DeepSeek 余额'
   labelEl.style.color = ''
+  amountEl.style.display = ''
   amountEl.className = 'dshwv-amount'
   amountEl.style.color = ''
+  hintEl.style.display = ''
   hintEl.className = 'dshwv-hint'
   hintEl.style.color = ''
   render()


### PR DESCRIPTION
## 问题

显示过单行随机台词（`singleCenter` 生成的 `[null, X, null]`）后，`applyBubbleLines()` 会把 label 行和 hint 行设为 `display:none`；气泡重开时 `restoreBubbleLines()` 只恢复了 `labelEl.style.display`，导致「今日已用」提示行从此消失，直到随机抽中三行台词组才暂时恢复。

复现步骤与截图见 #9。

## 修复

在 `restoreBubbleLines()` 中补回两行 display 复位：

```js
amountEl.style.display = ''
hintEl.style.display = ''
```

Fixes #9
