### PR TITLE
feat: 记住挂件拖拽位置，刷新后保持上次位置

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -769,7 +769,8 @@ var lastCostSeq = 0
 var costBubbleActive = false
 function saveConfig() {
   try {
-    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs }) })
+    var vp = viewport()
+    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs, h: state.h, v: state.v, hOff: state.hOff, vOff: state.vOff, leftFrac: vp.w ? state.left / vp.w : null, topFrac: vp.h ? state.top / vp.h : null }) })
   } catch (err) {}
 }
 function setUsageMode(v) {
@@ -1135,6 +1136,7 @@ function endDrag(e, clickAllowed) {
   state.left = left
   state.top = top
   settle()
+  saveConfig()
 }
 window.addEventListener('resize', function () {
   settle()
@@ -1191,6 +1193,16 @@ fetch(SIZE_URL, { cache: 'no-store' })
     if (d && typeof d.turnCostCloseMs === 'number') {
       turnCostCloseMs = d.turnCostCloseMs > 0 ? d.turnCostCloseMs : 0
       turnCostCloseInput.value = String(Math.round(turnCostCloseMs / 1000))
+    }
+    if (d && (typeof d.h === 'string' || typeof d.v === 'string' || typeof d.leftFrac === 'number')) {
+      var vp2 = viewport()
+      if (d.h === 'left' || d.h === 'right' || d.h === null) state.h = d.h
+      if (d.v === 'top' || d.v === 'bottom' || d.v === null) state.v = d.v
+      if (typeof d.hOff === 'number') state.hOff = d.hOff
+      if (typeof d.vOff === 'number') state.vOff = d.vOff
+      if (typeof d.leftFrac === 'number' && vp2.w) state.left = d.leftFrac * vp2.w
+      if (typeof d.topFrac === 'number' && vp2.h) state.top = d.topFrac * vp2.h
+      settle()
     }
     refresh(false)
   })
@@ -1568,6 +1580,12 @@ function apply(ctx) {
               bubbleOn: parsed.bubbleOn !== false,
               turnCostOn: parsed.turnCostOn !== false,
               turnCostCloseMs: typeof parsed.turnCostCloseMs === 'number' ? parsed.turnCostCloseMs : 5000,
+              h: typeof parsed.h === 'string' ? parsed.h : undefined,
+              v: typeof parsed.v === 'string' ? parsed.v : undefined,
+              hOff: typeof parsed.hOff === 'number' ? parsed.hOff : undefined,
+              vOff: typeof parsed.vOff === 'number' ? parsed.vOff : undefined,
+              leftFrac: typeof parsed.leftFrac === 'number' ? parsed.leftFrac : undefined,
+              topFrac: typeof parsed.topFrac === 'number' ? parsed.topFrac : undefined,
             }
           }
         } catch (err) {}
@@ -1575,7 +1593,7 @@ function apply(ctx) {
       return null
     }
 
-    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs) {
+    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs, h, v, hOff, vOff, leftFrac, topFrac) {
       const um = normalizeUsageMode(usageMode)
       const pm = peakMode === 'liangwen' || peakMode === 'qiangqiang' ? peakMode : 'default'
       const bo = bubbleOn !== false
@@ -1591,6 +1609,12 @@ function apply(ctx) {
         bubbleOn: bo,
         turnCostOn: tco,
         turnCostCloseMs: tcc,
+        h: h,
+        v: v,
+        hOff: typeof hOff === 'number' ? hOff : undefined,
+        vOff: typeof vOff === 'number' ? vOff : undefined,
+        leftFrac: typeof leftFrac === 'number' ? leftFrac : undefined,
+        topFrac: typeof topFrac === 'number' ? topFrac : undefined,
         updatedAt: new Date().toISOString(),
       })
       for (const p of SIZE_FILE_CANDIDATES) {
@@ -1718,7 +1742,7 @@ function apply(ctx) {
                 balanceCache = null
               }
             }
-            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs)
+            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs, parsed.h, parsed.v, parsed.hOff, parsed.vOff, parsed.leftFrac, parsed.topFrac)
             res.writeHead(result.ok ? 200 : 500, JSON_HEADERS)
             res.end(JSON.stringify(result))
           } catch (err) {


### PR DESCRIPTION
### 背景

目前大肥鱼挂件每次刷新页面都会回到右下角默认位置，且拖拽后的位置不会被记住，容易和退出、其他右下角的按钮重叠导致误触。

### 改动

在 `saveConfig()` / `readSizeConfig()` / `writeSizeConfig()` 中增加了位置持久化逻辑：

- **保存**：`saveConfig()` 增加 `h/v/hOff/vOff`（锚点方向与偏移）和 `leftFrac/topFrac`（视口相对比例）
- **拖拽即存**：`endDrag()` 末尾调用 `saveConfig()`，拖完自动保存
- **加载恢复**：页面启动时读取配置文件，按当前视口宽高换算回像素坐标，`settle()` 恢复
- **相对位置**：位置以 `leftFrac = left / vp.w` 存储，跨窗口尺寸保持相对位置不变

### 兼容性

- 旧配置文件（不含位置字段）→ 忽略，保持默认右下角位置，不报错
- 新配置文件 → 每次拖拽后更新，刷新后自动恢复

### 改动文件

- `lib/index.js` — 27 行新增，3 行修改