### PR TITLE
fix: gif 加载失败降级为文字台词 + 右缘滚动条避让

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -336,6 +336,8 @@ gifEl.src = GIF_URL
 gifEl.alt = ''
 gifEl.draggable = false
 bubbleBox.appendChild(gifEl)
+var gifFailed = false
+gifEl.onerror = function () { gifFailed = true }
 bubbleBox.appendChild(textBox)
 bubbleBox.addEventListener('click', function (e) {
   e.stopPropagation()
@@ -436,13 +438,18 @@ function pickRandomLines() {
 function applyBubbleLines(lines) {
   if (lines && lines.gif) {
     // gif 台词组：只显示 gif，隐藏三行文字（display 必须显式覆盖 CSS 的 none）
-    if (gifFadeTimer) { clearTimeout(gifFadeTimer); gifFadeTimer = null }
-    gifEl.style.display = 'block'
-    gifEl.style.opacity = ''
-    labelEl.style.display = 'none'
-    amountEl.style.display = 'none'
-    hintEl.style.display = 'none'
-    return
+    if (gifFailed) {
+      // gif 加载失败/路由缺失：降级为文字台词，避免空白白色气泡
+      lines = singleCenter('A', pickOne(['gif 加载失败了...', '今天没有动图给你看~', '呜呜 动图不见了...']), '', true)
+    } else {
+      if (gifFadeTimer) { clearTimeout(gifFadeTimer); gifFadeTimer = null }
+      gifEl.style.display = 'block'
+      gifEl.style.opacity = ''
+      labelEl.style.display = 'none'
+      amountEl.style.display = 'none'
+      hintEl.style.display = 'none'
+      return
+    }
   }
   if (gifFadeTimer) { clearTimeout(gifFadeTimer); gifFadeTimer = null }
   gifEl.style.display = 'none'
@@ -605,6 +612,11 @@ function viewport() {
     h: window.innerHeight || document.documentElement.clientHeight || 800
   }
 }
+function rightGap() {
+  var sw = window.innerWidth - document.documentElement.clientWidth
+  if (sw < 8) sw = 10 // 悬浮滚动条测量为0时兜底
+  return sw + 2 // 滚动条宽度 + 2px
+}
 function fmt(balance, currency) {
   var num = Number(balance)
   var fixed = isFinite(num) ? num.toFixed(2) : '--'
@@ -671,17 +683,17 @@ function settle() {
   var h = root.offsetHeight || root.getBoundingClientRect().height || 0
   if (drag && drag.active) {
     // mid-drag resize: keep the pointer-follow position, just clamp into view
-    state.left = clamp(state.left, 0, Math.max(0, vp.w - w))
+    state.left = clamp(state.left, 0, Math.max(0, vp.w - w - rightGap()))
     state.top = clamp(state.top, 0, Math.max(0, vp.h - h))
     express()
     return
   }
   if (state.h === 'right') {
-    state.left = Math.max(0, vp.w - w - state.hOff)
+    state.left = Math.max(0, vp.w - w - state.hOff - rightGap())
   } else if (state.h === 'left') {
     state.left = state.hOff
   } else {
-    state.left = clamp(state.left, 0, Math.max(0, vp.w - w))
+    state.left = clamp(state.left, 0, Math.max(0, vp.w - w - rightGap()))
   }
   if (state.v === 'bottom') {
     state.top = Math.max(0, vp.h - h - state.vOff)
@@ -955,7 +967,7 @@ function snapCheck() {
   } else if (centerX > vp.w * 3 / 4) {
     state.h = 'right'
     state.hOff = 0
-    left = vp.w - w
+    left = vp.w - w - rightGap()
     moved = true
   } else {
     state.h = null


### PR DESCRIPTION
- gif 台词组：rua.gif 加载失败/路由缺失时显示文字台词（避免空白白色气泡）
- 定位：右缘贴边/钳制预留滚动条宽度（rightGap = 滚动条宽 + 2px），不被滚动条遮挡
- ## 变更内容

两个小修复：

1. **gif 加载失败降级**：随机台词命中 gif 组但 `rua.gif` 加载失败时，自动降级为文字台词，避免气泡变成空白（只有白底没有内容）。

2. **右缘滚动条避让**：挂件右缘贴边/钳制时预留滚动条宽度（`rightGap = 滚动条宽度 + 2px`），避免被滚动条遮挡，悬浮滚动条场景兜底 10px。

## 为什么做

- gif 降级：gif 资源不可用（旧版本/安装不完整）时气泡显示空白，体验差。
- 滚动条避让：Windows 滚动条常驻时，贴右缘的挂件会被滚动条盖住一部分。

## 测试方法

1. 安装插件刷新页面
2. 随机台词命中 gif 组 → 正常显示 rua.gif
3. 临时改名 rua.gif → 再点台词 → 显示文字降级台词（不白屏）
4. 有滚动条时拖到右缘 → 挂件距右缘 = 滚动条宽度 + 2px