### PR TITLE
feat: 动态形象文件夹 assets/skins/（放图刷新即见，菜单可选）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,51 @@ const IMAGE_CANDIDATES = [
   'D:/TestBox/deepseek/skin/DSniang02.png',
 ]
 
+// 形象（skin）：动态扫描 assets/skins/ 目录，每放一张图（.png/.gif）刷新即可见。
+const SKINS_DIR = path.join(PACKAGE_ROOT, 'assets', 'skins')
+const SKIN_NAME_OVERRIDES = { 'DSniang1': '原版鲸鱼', 'DSniang2': '鲸鱼娘' }
+const SKIN_EXT = ['.png', '.gif']
+function listSkins() {
+  const skins = []
+  try {
+    const names = fs.readdirSync(SKINS_DIR)
+    for (const n of names) {
+      const lower = n.toLowerCase()
+      if (!SKIN_EXT.some(e => lower.endsWith(e))) continue
+      const id = n.slice(0, n.length - path.extname(n).length)
+      skins.push({ id, name: SKIN_NAME_OVERRIDES[id] || id })
+    }
+  } catch (err) {}
+  if (skins.length === 0) skins.push({ id: 'default', name: '原版鲸鱼' })
+  return skins
+}
+function findSkinFile(id) {
+  try {
+    const names = fs.readdirSync(SKINS_DIR)
+    for (const n of names) {
+      const lower = n.toLowerCase()
+      if (!SKIN_EXT.some(e => lower.endsWith(e))) continue
+      if (n.slice(0, n.length - path.extname(n).length) === id) return path.join(SKINS_DIR, n)
+    }
+  } catch (err) {}
+  return null
+}
+function skinExists(id) {
+  return listSkins().some(s => s.id === id)
+}
+function defaultSkinId() {
+  const skins = listSkins()
+  return skins.length ? skins[0].id : 'default'
+}
+function skinFromUrl(url) {
+  try {
+    const q = String(url || '').split('?')[1] || ''
+    const m = /(?:^|&)skin=([^&]+)/.exec(q)
+    const skin = m ? decodeURIComponent(m[1]) : ''
+    return skinExists(skin) ? skin : defaultSkinId()
+  } catch (err) { return defaultSkinId() }
+}
+
 // Size memory file: prefer writable DSH home locations, then legacy fallbacks.
 const SIZE_FILE_CANDIDATES = [
   path.join(DSH_HOME, '.dshw-size.json'),
@@ -115,7 +160,15 @@ var BUBBLE_MS = 5000
 var FETCH_TIMEOUT_MS = 25000
 var BALANCE_URL = '/dsh-whale/balance.json'
 var SIZE_URL = '/dsh-whale/size.json'
-var IMG_URL = '/dsh-whale/image.png?v=2'
+var IMG_URL = '/dsh-whale/image.png?v=3'
+var SKINS_URL = '/dsh-whale/skins.json'
+var skins = [] // 动态形象列表 [{id, name}]（从 assets/skins/ 扫描）
+var skin = ''
+function skinUrl(id) { return '/dsh-whale/image.png?v=3&skin=' + encodeURIComponent(id) }
+function skinInList(id) {
+  for (var i = 0; i < skins.length; i++) { if (skins[i].id === id) return true }
+  return false
+}
 var GIF_URL = '/dsh-whale/rua.gif'
 
 var css = [
@@ -291,6 +344,13 @@ row5.appendChild(peakSelect)
 var row6 = menuRow()
 row6.appendChild(menuLabel('气泡'))
 row6.appendChild(bubbleToggle)
+var skinSelect = document.createElement('select')
+skinSelect.className = 'dshwv-sound'
+skinSelect.addEventListener('change', function () { setSkin(skinSelect.value) })
+var rowSkin = menuRow()
+rowSkin.appendChild(menuLabel('形象'))
+rowSkin.appendChild(skinSelect)
+menuBox.appendChild(rowSkin)
 var menuSep1 = document.createElement('div')
 menuSep1.className = 'dshwv-menu-sep'
 var row7 = menuRow()
@@ -767,9 +827,17 @@ var turnCostOn = true
 var turnCostCloseMs = 5000
 var lastCostSeq = 0
 var costBubbleActive = false
+function setSkin(v) {
+  if (!skinInList(v)) v = skins.length ? skins[0].id : ''
+  skin = v
+  skinSelect.value = skin
+  IMG_URL = skin ? skinUrl(skin) : '/dsh-whale/image.png?v=3'
+  try { img.src = IMG_URL } catch (err) {}
+  saveConfig()
+}
 function saveConfig() {
   try {
-    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs }) })
+    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs, skin: skin }) })
   } catch (err) {}
 }
 function setUsageMode(v) {
@@ -1147,7 +1215,8 @@ express()
 render()
 applySoundSet()
 setupHitTest()
-fetch(SIZE_URL, { cache: 'no-store' })
+function loadSizeConfig() {
+  fetch(SIZE_URL, { cache: 'no-store' })
   .then(function (r) { return r.json() })
   .then(function (d) {
     if (d && typeof d.scale === 'number' && d.scale >= MIN_SCALE - 0.1 && d.scale <= MAX_SCALE + 0.1) {
@@ -1193,8 +1262,33 @@ fetch(SIZE_URL, { cache: 'no-store' })
       turnCostCloseInput.value = String(Math.round(turnCostCloseMs / 1000))
     }
     refresh(false)
+    if (d && typeof d.skin === 'string') {
+      // 保存的形象若已被删除，回退到列表第一个
+      skin = skinInList(d.skin) ? d.skin : (skins.length ? skins[0].id : '')
+      skinSelect.value = skin
+      IMG_URL = skin ? skinUrl(skin) : '/dsh-whale/image.png?v=3'
+      try { img.src = IMG_URL } catch (err) {}
+    }
+    refresh(false)
   })
   .catch(function () { refresh(false) })
+}
+// 先加载动态形象列表（assets/skins/ 扫描），构建菜单选项，再恢复配置
+fetch(SKINS_URL, { cache: 'no-store' })
+  .then(function (r) { return r.json() })
+  .then(function (d) {
+    if (d && d.ok && Array.isArray(d.skins) && d.skins.length > 0) {
+      skins = d.skins
+      // 重建「形象」下拉选项（保留当前选中值）
+      skinSelect.innerHTML = ''
+      for (var i = 0; i < skins.length; i++) {
+        skinSelect.appendChild(soundOpt(skins[i].id, skins[i].name))
+      }
+      skinSelect.value = skin
+    }
+    loadSizeConfig()
+  })
+  .catch(function () { loadSizeConfig() })
 setInterval(function () { refresh(false) }, REFRESH_MS)
 
 // —— 每轮对话消耗检测：轮询 last-turn.json，出现新 seq 时弹消耗金额泡泡 ——
@@ -1308,18 +1402,23 @@ function apply(ctx) {
       throw new Error('rua gif not found')
     }
 
-    function loadImage() {
-      if (imageBytes) return imageBytes
-      for (const p of IMAGE_CANDIDATES) {
+    function loadImage(skin) {
+      const sk = skinExists(skin) ? skin : defaultSkinId()
+      const key = 'skin:' + sk
+      if (imageBytes && imageBytes[key]) return imageBytes[key]
+      const file = findSkinFile(sk)
+      const candidates = file ? [file] : IMAGE_CANDIDATES
+      for (const p of candidates) {
         try {
           const bytes = fs.readFileSync(p)
           if (bytes && bytes.length > 0) {
-            imageBytes = bytes
+            imageBytes = imageBytes || {}
+            imageBytes[key] = bytes
             return bytes
           }
         } catch (err) {}
       }
-      throw new Error('whale image not found')
+      throw new Error('whale image not found (skin ' + sk + ')')
     }
 
     async function fetchBalance() {
@@ -1568,6 +1667,7 @@ function apply(ctx) {
               bubbleOn: parsed.bubbleOn !== false,
               turnCostOn: parsed.turnCostOn !== false,
               turnCostCloseMs: typeof parsed.turnCostCloseMs === 'number' ? parsed.turnCostCloseMs : 5000,
+              skin: typeof parsed.skin === 'string' && skinExists(parsed.skin) ? parsed.skin : defaultSkinId(),
             }
           }
         } catch (err) {}
@@ -1575,7 +1675,7 @@ function apply(ctx) {
       return null
     }
 
-    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs) {
+    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs, skin) {
       const um = normalizeUsageMode(usageMode)
       const pm = peakMode === 'liangwen' || peakMode === 'qiangqiang' ? peakMode : 'default'
       const bo = bubbleOn !== false
@@ -1591,6 +1691,7 @@ function apply(ctx) {
         bubbleOn: bo,
         turnCostOn: tco,
         turnCostCloseMs: tcc,
+        skin: typeof skin === 'string' && skinExists(skin) ? skin : defaultSkinId(),
         updatedAt: new Date().toISOString(),
       })
       for (const p of SIZE_FILE_CANDIDATES) {
@@ -1607,6 +1708,7 @@ function apply(ctx) {
             bubbleOn: bo,
             turnCostOn: tco,
             turnCostCloseMs: tcc,
+            skin: typeof skin === 'string' && skinExists(skin) ? skin : defaultSkinId(),
           }
         } catch (err) {}
       }
@@ -1636,7 +1738,7 @@ function apply(ctx) {
       path: '/dsh-whale/image.png',
       handler: (req, res) => {
         try {
-          const bytes = loadImage()
+          const bytes = loadImage(skinFromUrl(req.url))
           res.writeHead(200, {
             'Content-Type': 'image/png',
             'Cache-Control': 'no-store',
@@ -1646,6 +1748,22 @@ function apply(ctx) {
         } catch (err) {
           res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
           res.end('whale image unavailable: ' + String((err && err.message) || err))
+        }
+      },
+    }))
+
+    disposers.push(ctx.webServer.register({
+      kind: 'exact',
+      kind: 'exact',
+      path: '/dsh-whale/skins.json',
+      handler: (req, res) => {
+        try {
+          const list = listSkins()
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: true, skins: list.map(sk => ({ id: sk.id, name: sk.name })) }))
+        } catch (err) {
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: false, error: String((err && err.message) || err).slice(0, 200) }))
         }
       },
     }))
@@ -1718,7 +1836,7 @@ function apply(ctx) {
                 balanceCache = null
               }
             }
-            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs)
+            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs, parsed.skin)
             res.writeHead(result.ok ? 200 : 500, JSON_HEADERS)
             res.end(JSON.stringify(result))
           } catch (err) {


### PR DESCRIPTION
- 宿主: 扫描 assets/skins/ 目录（.png/.gif），/dsh-whale/skins.json 返回形象列表；image.png?skin=<id> 按 id 读文件（skins 空时回退原图）；size.json 持久化 skin 选择
- 前端: 菜单新增「形象」下拉（动态构建）；选择即时换图并记忆；保存的形象被删除则自动回退第一个
- 已知文件名映射中文名（DSniang1→原版鲸鱼、DSniang2→鲸鱼娘），新图用文件名
- 用法：往 assets/skins/ 放任意 .png/.gif，刷新浏览器即可在菜单选择
- ## 功能：动态形象文件夹

往 `assets/skins/` 文件夹里放一张图（`.png` / `.gif`），**刷新浏览器**，设置菜单的「形象」下拉就自动出现新选项，可随时切换 —— 无需改代码、无需重启。

## 为什么做

目前形象是写死的（只能显示默认鲸鱼图）。这个功能让用户可以：
1. 往 `assets/skins/` 丢任意图片即成为可选形象
2. 菜单「形象」下拉自由切换，选择被记住（size.json 持久化）
3. 用户手动选择 + 无限多形象

## 改动点

- **宿主**：`listSkins()` 实时扫描 `assets/skins/`（每次请求）；新增 `/dsh-whale/skins.json` 返回形象列表；`/dsh-whale/image.png?skin=<id>` 按 id 读文件（skins 目录为空时回退原图）；`size.json` 持久化 `skin` 字段
- **前端**：菜单新增「形象」下拉（从 skins.json 动态构建）；选择即时换图并保存；已保存的形象被删除时自动回退第一个
- 已知文件名映射中文名（`DSniang1`→原版鲸鱼、`DSniang2`→鲸鱼娘），新图默认显示文件名

## 测试方法

1. 安装后刷新页面
2. 菜单「形象」出现「原版鲸鱼」选项
3. 往 `assets/skins/` 放任意 `xx.png` → 刷新 → 下拉出现 `xx` → 选择即换图
4. 刷新页面 → 形象保持（记忆生效）
5. 删除该图 → 刷新 → 自动回退第一个形象