### PR TITLE
feat: 锚点位置记忆（相对边框，窗口变化不悬空/能吸回原位）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -770,6 +770,19 @@ var costBubbleActive = false
 function saveConfig() {
   try {
     fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs }) })
+    var vp = viewport()
+    var w = root.offsetWidth || root.getBoundingClientRect().width || 0
+    var h = root.offsetHeight || root.getBoundingClientRect().height || 0
+    var leftDist = state.left
+    var rightDist = vp.w - state.left - w
+    var topDist = state.top
+    var bottomDist = vp.h - state.top - h
+    localStorage.setItem('dshw-pos', JSON.stringify({
+      hAnchor: leftDist <= rightDist ? 'left' : 'right',
+      hDist: Math.round(Math.min(leftDist, rightDist)),
+      vAnchor: topDist <= bottomDist ? 'top' : 'bottom',
+      vDist: Math.round(Math.min(topDist, bottomDist))
+    }))
   } catch (err) {}
 }
 function setUsageMode(v) {
@@ -1136,7 +1149,28 @@ function endDrag(e, clickAllowed) {
   state.top = top
   settle()
 }
+// 窗口尺寸变化时：自由位置的鲸鱼按相对边框锚点重算（保持离边距离，窗口恢复原状即回原位）；
+// 贴边吸附的鲸鱼走 settle()（保持贴边）
+function applyAnchorPos() {
+  try {
+    var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
+    if (!a || (a.hAnchor !== 'left' && a.hAnchor !== 'right') || typeof a.hDist !== 'number' ||
+        (a.vAnchor !== 'top' && a.vAnchor !== 'bottom') || typeof a.vDist !== 'number') return false
+    var vp = viewport()
+    var w = root.offsetWidth || root.getBoundingClientRect().width || 0
+    var h = root.offsetHeight || root.getBoundingClientRect().height || 0
+    var l = a.hAnchor === 'left' ? a.hDist : vp.w - a.hDist - w
+    var t = a.vAnchor === 'top' ? a.vDist : vp.h - a.vDist - h
+    state.left = clamp(l, 0, Math.max(0, vp.w - w))
+    state.top = clamp(t, 0, Math.max(0, vp.h - h))
+    state.h = null
+    state.v = null
+    express()
+    return true
+  } catch (err) { return false }
+}
 window.addEventListener('resize', function () {
+  if (state.h === null && state.v === null && applyAnchorPos()) return
   settle()
 })
 
@@ -1192,6 +1226,23 @@ fetch(SIZE_URL, { cache: 'no-store' })
       turnCostCloseMs = d.turnCostCloseMs > 0 ? d.turnCostCloseMs : 0
       turnCostCloseInput.value = String(Math.round(turnCostCloseMs / 1000))
     }
+    // 相对边框恢复（localStorage 锚点）：窗口变化后保持离边距离
+    try {
+      var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
+      if (a && (a.hAnchor === 'left' || a.hAnchor === 'right') && typeof a.hDist === 'number' &&
+          (a.vAnchor === 'top' || a.vAnchor === 'bottom') && typeof a.vDist === 'number') {
+        var vpA = viewport()
+        var wA = root.offsetWidth || root.getBoundingClientRect().width || 0
+        var hA = root.offsetHeight || root.getBoundingClientRect().height || 0
+        var lA = a.hAnchor === 'left' ? a.hDist : vpA.w - a.hDist - wA
+        var tA = a.vAnchor === 'top' ? a.vDist : vpA.h - a.vDist - hA
+        state.left = clamp(lA, 0, Math.max(0, vpA.w - wA))
+        state.top = clamp(tA, 0, Math.max(0, vpA.h - hA))
+        state.h = null // 恢复为自由位置，避免 settle() 重新吸附覆盖
+        state.v = null
+        settle()
+      }
+    } catch (err) {}
     refresh(false)
   })
   .catch(function () { refresh(false) })


### PR DESCRIPTION
- 保存：位置换算为「离最近边框的距离」存 localStorage（dshw-pos）
- 恢复：刷新时按当前窗口尺寸重算，保持相对位置（不悬空、不跳变）
- resize：自由位置的鲸鱼按锚点重算 —— 打开/关闭 DevTools 等窗口变化后回到原相对位置
- 与 #14（绝对坐标记忆）的区别：本方案记的是相对边框距离，窗口尺寸变化后位置比例稳定，不会悬空/贴边跳变
- ## 功能：锚点位置记忆（相对边框）

挂件位置改为记忆"离最近边框的距离"，而不是绝对坐标：

1. **保存**：拖拽后把位置换算为锚点（贴哪条边 + 离边距离）存 localStorage
2. **刷新恢复**：按当前窗口尺寸重算位置，保持相对距离 —— 窗口变了不悬空、不贴边跳变
3. **resize 重算**：打开/关闭 DevTools（浏览器开发者工具）等窗口尺寸变化时，自由位置的挂件按锚点回到原相对位置（"吸回原位"）
本方案是**相对边框锚点**：记的是"离右边 50px、离底边 30px"这种距离，窗口怎么变都保持相对位置，窗口恢复原状挂件回到原位。两者可互补。

## 改动点

纯前端（lib/index.js 内嵌字符串，+51 行）：
- `saveConfig()`：位置换算为锚点存 localStorage（`dshw-pos`）
- 配置恢复链：锚点优先恢复，按当前视口重算 + 越界钳制
- `resize` 监听：自由位置挂件按锚点重算（贴边挂件保持原 settle() 贴边逻辑）

## 测试方法

1. 拖到任意位置（不贴边）→ 刷新 → 位置保持
2. 拖到中间偏右 → F12 打开开发者工具（窗口变窄）→ 挂件跟到右边 → 关闭 → 挂件回到原相对位置
3. 窗口拉大/缩小 → 刷新 → 相对边框距离不变