### PR TITLE
fix: 每轮消耗泡泡两处缺陷（0 秒不持久化 / 关闭气泡冻结渲染）+ 清理

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -765,7 +765,6 @@ var peakMode = 'default'
 var bubbleOn = true
 var turnCostOn = true
 var turnCostCloseMs = 5000
-var lastCostSeq = 0
 var costBubbleActive = false
 function saveConfig() {
   try {
@@ -787,7 +786,8 @@ function setBubbleOn(v) {
   bubbleOn = !!v
   bubbleToggle.checked = bubbleOn
   saveConfig()
-  if (!bubbleOn) hideBubble()
+  // 必须走 hideCostBubble：残留的 costBubbleActive 会让 render()/showBubble() 永久早退
+  if (!bubbleOn) hideCostBubble()
 }
 function setTurnCostOn(v) {
   turnCostOn = !!v
@@ -1009,7 +1009,9 @@ function setupHitTest() {
     var probe = new Image()
     probe.onload = function () {
       try {
-        hitCanvas.getContext('2d').drawImage(probe, 0, 0)
+        // 拉伸到 610×610 与 isWhaleHit 的坐标映射对齐；不指定尺寸会按原图大小绘制，
+        // 回退到非 610×610 素材（如 DSniang02.png）时命中区域会错位
+        hitCanvas.getContext('2d').drawImage(probe, 0, 0, 610, 610)
         hitReady = true
       } catch (err) {}
     }
@@ -1287,10 +1289,6 @@ function apply(ctx) {
 
     // 监听所有会话的追加事件；turn/end 时结算本轮
     disposers.push(ctx.on('session/event', (session, event) => {
-      // [debug] 确认事件是否到达（下个版本移除）
-      if (event && (event.type === 'turn/end' || event.type === 'assistant/message')) {
-        try { console.error('[whale-balance:event]', event.type, 'turn=' + (event.data && event.data.turn), 'usage=' + (event.data && event.data.usage ? 'yes' : 'no')) } catch (err) {}
-      }
       handleSessionEvent(event)
     }))
 
@@ -1580,7 +1578,8 @@ function apply(ctx) {
       const pm = peakMode === 'liangwen' || peakMode === 'qiangqiang' ? peakMode : 'default'
       const bo = bubbleOn !== false
       const tco = turnCostOn !== false
-      const tcc = typeof turnCostCloseMs === 'number' && turnCostCloseMs > 0 ? turnCostCloseMs : 5000
+      // 0 是合法值（不自动关闭），只有缺失/非法时才回落默认 5 秒
+      const tcc = typeof turnCostCloseMs === 'number' && turnCostCloseMs >= 0 ? turnCostCloseMs : 5000
       const body = JSON.stringify({
         scale: scale,
         sound: sound !== false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-whale-widget",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "DSH Web 界面右下角的 DeepSeek 余额小鲸鱼挂件（含今日已用、峰谷定价、随机台词、音效与每轮消耗统计）",
   "keywords": [
     "dsh",


### PR DESCRIPTION
## 修复

### 1. 「自动关闭时间 = 0（不自动关闭）」无法持久化

`writeSizeConfig` 里 `turnCostCloseMs > 0 ? ... : 5000` 把 0 强制改写成 5000 存盘。前端允许设 0（菜单输入框 title 明确「填 0 表示不自动关闭」），但当次会话生效后刷新页面就变回 5 秒。改为 `>= 0`，只有缺失/非法才回落默认值。

### 2. 消耗泡泡显示期间关闭「气泡」开关会永久冻结挂件

`setBubbleOn(false)` 原来调 `hideBubble()`，不清 `costBubbleActive` / `costBubbleTimer`。若此时消耗泡泡正在显示且自动关闭时间为 0，`costBubbleActive` 永远为 true，而 `render()`、`animateAmount()`、`showBubble()` 开头都有 `if (costBubbleActive) return`——余额停止刷新、气泡再也弹不出，重新勾选也无效，只能刷新页面。改为调 `hideCostBubble()`（与 `setTurnCostOn` 一致）。自动关闭 > 0 时也顺便消除了残留定时器的晚触发。

## 顺手清理

- 命中检测画布 `drawImage(probe, 0, 0)` 按原图尺寸绘制，回退到非 610×610 素材（如 `DSniang02.png` 1026×1026）时点击/拖拽区域会错位；改为固定拉伸 `610, 610` 与 `isWhaleHit` 坐标映射对齐
- 移除 `session/event` 的调试 `console.error`（上版注释自述「下个版本移除」，每条 assistant/message 都会打）
- 删除重复声明的 `var lastCostSeq`（768/1202 两处，前者是死代码）

## 其他

- 版本号 0.2.5 → 0.2.6，按仓库发版流程合并后自动发布 npm（已验证 0.2.5 的 OIDC 发布链路正常）
- 模块与内嵌 widget.js 均通过语法编译校验；手动验证路径：设自动关闭时间为 0 → 刷新页面确认仍为 0；消耗泡泡显示时取消勾选「气泡」→ 60 秒后余额仍正常刷新