### PR TITLE
fix: 点击穿透（#21）与 #20 反馈：并发串账 / v4-pro 定价 / README 命令 / 位置落盘

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ dsh-whale-widget/
 在项目根目录（`DeepSeek-Balance-Whale-Widget-main`）执行：
 
 ```powershell
-dsh plugin --profile web add link:.\dsh-whale-widget
+dsh plugin --profile web add link:.
 ```
 
 说明：
@@ -58,7 +58,7 @@ dsh plugin --profile web add link:.\dsh-whale-widget
 - 安装完成后重启 `dsh web`，再 F5 刷新浏览器
 - **如果之后移动了源码目录**，必须重新到新的项目根目录执行一次：
   ```powershell
-  dsh plugin --profile web add link:.\dsh-whale-widget
+  dsh plugin --profile web add link:.
   ```
   因为 `link:` 记录的是源目录的绝对路径；移动后旧链接会失效。若提示已存在/冲突，可先 `dsh plugin --profile web remove dsh-whale-widget` 再重新 add。
 
@@ -67,7 +67,6 @@ dsh plugin --profile web add link:.\dsh-whale-widget
 如果你把这个包发布到 npm：
 
 ```powershell
-cd dsh-whale-widget
 npm publish
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,11 +69,14 @@ const PEAK_HOURS = [
   [14, 18],
 ]
 const BASE_PRICE = { hit: [0.05, 0.1], miss: [1.5, 3.0], out: [4.5, 9.0] }
+// deepseek-v4-pro 是 flash 的 3 倍价（官方价目 2026-08-17 生效）；
+// v4-flash-vision-exp 与 flash 同价，靠前缀 'deepseek-v4-flash' 命中
+const PRO_PRICE = { hit: [0.15, 0.3], miss: [4.5, 9.0], out: [13.5, 27.0] }
 const PRICING = {
   'deepseek-chat': BASE_PRICE,
   'deepseek-reasoner': BASE_PRICE,
   'deepseek-v4-flash': BASE_PRICE,
-  'deepseek-v4-pro': BASE_PRICE,
+  'deepseek-v4-pro': PRO_PRICE,
   _default: BASE_PRICE,
 }
 function priceFor(model) {
@@ -778,9 +781,10 @@ var bubbleOn = true
 var turnCostOn = true
 var turnCostCloseMs = 5000
 var costBubbleActive = false
-function saveConfig() {
+// 锚点位置记忆：把当前位置换算成「相对最近边框的距离」存 localStorage。
+// 拖拽/吸附落定、改尺寸后都要调用，否则刷新页面回到的是上次保存的旧位置。
+function savePos() {
   try {
-    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs }) })
     var vp = viewport()
     var w = root.offsetWidth || root.getBoundingClientRect().width || 0
     var h = root.offsetHeight || root.getBoundingClientRect().height || 0
@@ -795,6 +799,12 @@ function saveConfig() {
       vDist: Math.round(Math.min(topDist, bottomDist))
     }))
   } catch (err) {}
+}
+function saveConfig() {
+  try {
+    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs }) })
+  } catch (err) {}
+  savePos()
 }
 function setUsageMode(v) {
   usageMode = v === 'token' ? 'token' : 'ledger'
@@ -842,7 +852,6 @@ function setScale(v) {
   root.style.setProperty('--dshw-scale', String(next))
   scaleInput.value = String(next)
   scaleNumber.value = String(scaleToDisplay(next))
-  saveConfig()
   // keep the corner fixed while resizing; the position correction applies
   // instantly because the caller disables the transition for the whole drag
   var r2 = root.getBoundingClientRect()
@@ -854,6 +863,8 @@ function setScale(v) {
   }
   state.top = Math.min(Math.max(fy - r2.height, 0), Math.max(0, vp.h - r2.height))
   express()
+  // 位置校正完成后再落盘（saveConfig 会一并保存锚点位置，提前调用会存进旧坐标）
+  saveConfig()
 }
 function setVol(v) {
   var next = Math.round(Math.min(1, Math.max(0, Number(v))) * 100) / 100
@@ -999,6 +1010,7 @@ function snapCheck() {
     state.left = left
     state.top = top
     settle()
+    savePos()
   }
 }
 function positionMenu() {
@@ -1060,6 +1072,8 @@ function isWhaleHit(e) {
   }
 }
 function onDocPointerDown(e) {
+  // 每次 pointerdown 先复位吞点击标志（click 必然跟在自己的 pointerdown 之后）
+  swallowNextClick = false
   if (e.target && e.target.closest) {
     if (e.target.closest('.dshwv-bubble') || e.target.closest('.dshwv-menu') || e.target.closest('.dshwv-menu-btn')) return
   }
@@ -1079,7 +1093,7 @@ function onDocPointerDown(e) {
   document.addEventListener('pointermove', onDocPointerMove, true)
   document.addEventListener('pointerup', onDocPointerUp, true)
   document.addEventListener('pointercancel', onDocPointerCancel, true)
-  document.addEventListener('click', onDocClickStopper, true)
+  swallowNextClick = true
 }
 function onDocPointerMove(e) {
   if (!drag || !drag.active) return
@@ -1095,9 +1109,16 @@ function onDocPointerMove(e) {
 }
 function onDocPointerUp(e) { endDrag(e, true) }
 function onDocPointerCancel(e) { endDrag(e, false) }
+// click 在 pointerup 之后才派发：如果在 endDrag（pointerup）里同步移除 click 监听，
+// 移除总是先于 click 发生，点击会漏给鲸鱼下方的元素（如 better-sidebar 的文件行）。
+// 改为常驻捕获监听 + 标志位：命中鲸鱼的 pointerdown 置位，click 消费后复位。
+var swallowNextClick = false
 function onDocClickStopper(e) {
+  if (!swallowNextClick) return
+  swallowNextClick = false
   try { e.preventDefault(); e.stopPropagation() } catch (err) {}
 }
+document.addEventListener('click', onDocClickStopper, true)
 document.addEventListener('pointerdown', onDocPointerDown, true)
 
 var widgetCursor = ''
@@ -1128,7 +1149,6 @@ function endDrag(e, clickAllowed) {
   document.removeEventListener('pointermove', onDocPointerMove, true)
   document.removeEventListener('pointerup', onDocPointerUp, true)
   document.removeEventListener('pointercancel', onDocPointerCancel, true)
-  document.removeEventListener('click', onDocClickStopper, true)
   pressUp()
   root.classList.remove('dshwv-dragging')
   setWidgetCursor(isWhaleHit(e) ? 'grab' : '')
@@ -1162,6 +1182,7 @@ function endDrag(e, clickAllowed) {
   state.left = left
   state.top = top
   settle()
+  savePos()
 }
 // 窗口尺寸变化时：自由位置的鲸鱼按相对边框锚点重算（保持离边距离，窗口恢复原状即回原位）；
 // 贴边吸附的鲸鱼走 settle()（保持贴边）
@@ -1300,60 +1321,86 @@ function apply(ctx) {
     let balanceCache = null
     let balanceInFlight = null
     let gifBytes = null
-    // 每轮对话消耗统计：turn -> 聚合中的成本/分词；完成后写入 lastTurn
-    let turnAgg = null // { turn, cost, tokens, lastTs }
+    // 每轮对话消耗统计：按 (会话, turn) 分桶聚合，完成后写入 lastTurn。
+    // 单桶只按 turn 号聚合时，并发会话（主会话/子代理）的同号 turn 会被合并
+    // 串账，一个会话的 turn/end 也会误结算另一个会话未完成的轮次。
+    const turnAggMap = new Map() // sessionKey -> { turn, cost, tokens, lastTs }
     let lastTurn = null // { turn, amount, tokens, ts }
     let lastTurnSeq = 0
     const disposers = []
 
-    function resetTurnAgg() {
-      turnAgg = null
+    function sessionKeyOf(session) {
+      const id = session && session.id !== undefined && session.id !== null ? session.id : ''
+      return id === '' ? '_anon' : String(id)
     }
-    function finalizeTurn() {
-      if (turnAgg && turnAgg.cost > 0) {
-        lastTurn = { turn: turnAgg.turn, amount: turnAgg.cost, tokens: turnAgg.tokens, ts: turnAgg.lastTs }
+    function finalizeTurn(key) {
+      const agg = turnAggMap.get(key)
+      if (agg && agg.cost > 0) {
+        lastTurn = { turn: agg.turn, amount: agg.cost, tokens: agg.tokens, ts: agg.lastTs }
         lastTurnSeq++
       }
-      turnAgg = null
+      turnAggMap.delete(key)
     }
-    // 监听会话事件流：assistant/message 携带每步真实 usage，按 turn 聚合；
-    // turn/end 时结算本轮并写入 lastTurn
-    function handleSessionEvent(event) {
+    // 监听会话事件流：assistant/message 携带每步真实 usage，按 (会话, turn) 聚合；
+    // turn/end 时结算该会话本轮并写入 lastTurn
+    function handleSessionEvent(session, event) {
       try {
         const type = event && event.type
         const d = event && event.data
         if (!d || typeof d !== 'object') return
+        const key = sessionKeyOf(session)
         if (type === 'turn/end') {
-          // 一轮对话结束：结算并清空聚合
-          finalizeTurn()
+          // 一轮对话结束：结算并清空该会话的聚合
+          finalizeTurn(key)
           return
         }
         if (type !== 'assistant/message') return
         const turn = Number(d.turn)
         const usage = d.usage
         if (!usage || typeof usage !== 'object' || !isFinite(turn)) return
-        if (!turnAgg || turnAgg.turn !== turn) {
-          if (turnAgg && turnAgg.turn !== turn) finalizeTurn()
-          if (!turnAgg || turnAgg.turn !== turn) turnAgg = { turn, cost: 0, tokens: 0, lastTs: Date.now() }
+        let agg = turnAggMap.get(key)
+        if (agg && agg.turn !== turn) {
+          // 同会话 turn 跳号：旧轮次已被放弃，先结算再开新桶
+          finalizeTurn(key)
+          agg = undefined
+        }
+        if (!agg) {
+          agg = { turn, cost: 0, tokens: 0, lastTs: Date.now() }
+          turnAggMap.set(key, agg)
+          // 会话既没有 turn/end 也没有 disposed 通知时的防泄漏兜底：桶数超限时淘汰最久未更新的
+          if (turnAggMap.size > 32) {
+            let oldestKey = null
+            let oldestTs = Infinity
+            for (const [k, v] of turnAggMap) {
+              if (v.lastTs < oldestTs) { oldestTs = v.lastTs; oldestKey = k }
+            }
+            if (oldestKey !== null && oldestKey !== key) turnAggMap.delete(oldestKey)
+          }
         }
         const input = Number(usage.inputTokens) || 0
         const cache = Number(usage.cacheReadTokens) || 0
         const output = Number(usage.outputTokens) || 0
         const reasoning = Number(usage.reasoningTokens) || 0
-        turnAgg.tokens += input + cache + output + reasoning
+        agg.tokens += input + cache + output + reasoning
         // 定价换算（CNY/百万 token；缓存命中=输入价，其余按各自档位）
         const model = d.message && d.message.source ? d.message.source.model : ''
         const p = priceFor(model)
         const off = isPeakTime(Math.floor(Date.now() / 1000)) ? 1 : 0
-        turnAgg.cost += (cache / 1e6) * p.hit[off] + (input / 1e6) * p.miss[off] + ((output + reasoning) / 1e6) * p.out[off]
-        turnAgg.lastTs = Date.now()
+        agg.cost += (cache / 1e6) * p.hit[off] + (input / 1e6) * p.miss[off] + ((output + reasoning) / 1e6) * p.out[off]
+        agg.lastTs = Date.now()
       } catch (err) {}
     }
 
-    // 监听所有会话的追加事件；turn/end 时结算本轮
+    // 监听所有会话的追加事件；turn/end 时结算该会话本轮
     disposers.push(ctx.on('session/event', (session, event) => {
-      handleSessionEvent(event)
+      handleSessionEvent(session, event)
     }))
+    // 会话销毁时清掉残留的聚合桶（频道不存在时注册失败可忽略，上面的超限淘汰兜底）
+    try {
+      disposers.push(ctx.on('session/disposed', (session) => {
+        turnAggMap.delete(sessionKeyOf(session))
+      }))
+    } catch (err) {}
 
     function loadGif() {
       if (gifBytes) return gifBytes

--- a/whale-widget-prompt.md
+++ b/whale-widget-prompt.md
@@ -68,15 +68,16 @@
 - **峰谷定价换算**：按每个小时桶的整点（北京时间 UTC+8）判定空闲/高峰，套用 `PRICING` 表（每百万 token 单价）求和：
   - 高峰时段：每日 9:00–12:00 与 14:00–18:00。
   - 单价（空闲 / 高峰）：缓存命中输入 0.05 / 0.10 元；缓存未命中输入 1.5 / 3.0 元；输出 4.5 / 9.0 元。
-  - 定价表在 `lib/index.js` 顶部 `PEAK_HOURS` / `BASE_PRICE` / `PRICING` 常量，DeepSeek 调价时改这里。
+  - `deepseek-v4-pro` 是上述价格的 **3 倍**（命中 0.15 / 0.30、未命中 4.5 / 9.0、输出 13.5 / 27.0，官方价目 2026-08-17 生效）；`v4-flash-vision-exp` 与 flash 同价（靠前缀 `deepseek-v4-flash` 命中）。
+  - 定价表在 `lib/index.js` 顶部 `PEAK_HOURS` / `BASE_PRICE` / `PRO_PRICE` / `PRICING` 常量，DeepSeek 调价时改这里。
 - 无令牌或令牌失效时自动回落记账模式（`usageMode` 仍标记为 'ledger'）。
 
 ### 每轮对话消耗（Host，会话事件监听）
 
 - 宿主插件 `ctx.on('session/event', ...)` 监听所有会话的追加事件流（Cordis 全局监听可收到，scope 默认向上传播）。
 - 捕获 `type === 'assistant/message'` 且带 `data.usage` 的事件：`usage = { inputTokens, cacheReadTokens, outputTokens, reasoningTokens }`（模型返回的真实 token 计数，非估算）。
-- 按 `data.turn` 聚合：同一 turn 的多步（step）usage 累加；成本换算复用峰谷定价表：`cacheRead→p.hit[off]`、`input→p.miss[off]`、`output+reasoning→p.out[off]`（off = 当前是否高峰）。
-- `type === 'turn/end'` 时结算本轮：写 `lastTurn = { turn, amount, tokens, ts }`，`lastTurnSeq++`。
+- 按 `(session.id, data.turn)` 分桶聚合：并发会话（主会话/子代理）的 turn 号各自独立，单桶按 turn 号聚合会串账；同一 turn 的多步（step）usage 累加；成本换算复用峰谷定价表：`cacheRead→p.hit[off]`、`input→p.miss[off]`、`output+reasoning→p.out[off]`（off = 当前是否高峰）。
+- `type === 'turn/end'` 时结算**该会话**本轮：写 `lastTurn = { turn, amount, tokens, ts }`，`lastTurnSeq++`；另监听 `session/disposed` 清理残留桶（并有桶数超限淘汰兜底）。
 - 前端 `/dsh-whale/last-turn.json` 每秒轮询：首次拿到数据只对齐 seq（不弹旧轮次），此后 `seq` 变大即「新的一轮」→ 弹消耗金额泡泡。
 - 消耗金额泡泡显示期间：`render()` / `animateAmount()` 均被 `costBubbleActive` 保护跳过（余额渲染/滚动不覆盖金额行）；余额变动也不弹普通泡泡（`showBubble()` 内 `if (costBubbleActive) return`）。
 - 关闭方式：点击泡泡确认关闭，或按 `turnCostCloseMs`（秒×1000）自动关闭；填 0 表示不自动关闭。


### PR DESCRIPTION
修复 #21 和 #20 中的问题（#20 的「遗留调试日志」已在 0.2.6 / #19 移除）。

## 1. 点击鲸鱼穿透到下方元素（#21）

根因与 issue 分析一致，且补一个时序细节：代码原本在 pointerdown 命中鲸鱼时挂 click 捕获拦截器、在 `endDrag`（pointerup）里同步移除——而 **click 在 pointerup 之后才派发**，拦截器总是先被摘掉，形同虚设，click 落到指针下方的真实命中目标（better-sidebar 的文件行）。

修法：改为**常驻** document 捕获 click 监听 + 标志位（`swallowNextClick`）：命中鲸鱼的 pointerdown 置位，click 消费后复位；每次 pointerdown 先复位，不会误吞非鲸鱼点击。未采用 `pointer-events:auto` 方案（会失去透明区域 alpha 精确命中）。

## 2. 并发会话每轮消耗串账（#20）

`turnAgg` 从单桶按 turn 号聚合改为 `Map<sessionKey, {turn, cost, tokens, lastTs}>` 按 `(session.id, turn)` 分桶；`turn/end` 只结算该会话；同会话 turn 跳号先结算旧桶。另监听 `session/disposed` 清理残留桶（注册失败忽略），并有 32 桶上限、最久未更新淘汰的兜底。峰谷判定仍用消息到达时刻（同步处理 ≈ 事件时间）。

## 3. v4-pro 定价低估 3 倍（#20）

已对照官方价目页核实：v4-pro 为 flash 的 3 倍。补 `PRO_PRICE = { hit: [0.15, 0.3], miss: [4.5, 9.0], out: [13.5, 27.0] }`；`v4-flash-vision-exp` 靠前缀 `deepseek-v4-flash` 命中 flash 价（与官方一致）。规格文档同步。

## 4. README 安装命令（#20）

`link:.\dsh-whale-widget` → `link:.`（仓库根目录即包），方式 B 去掉 `cd dsh-whale-widget`。

## 5. 锚点位置记忆不完整（#16 遗留）

`dshw-pos` 原先只在 `saveConfig()`（改菜单设置）时写入，拖拽/吸附后刷新会回到旧位置；且 `setScale` 里 `saveConfig()` 在位置校正**之前**执行，存进的是旧坐标。提取 `savePos()`，在 `endDrag`/`snapCheck` 落定后调用，`setScale` 改为校正后落盘。

## 验证

- 模块 import 与内嵌 widget.js `new Function` 编译均通过
- 建议实测：装 better-sidebar 点鲸鱼不误开文件；拖到新位置刷新页面位置保持；并发两个会话各跑一轮，金额各自独立

fix #21, fix #20