### PR TITLE
feat: 增加「投喂」功能（DeepSeek平台CNY余额充值）

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ DeepSeek Harness（DSH）Web 界面右下角的常驻余额挂件：小鲸鱼气
 - 💬 **每轮对话消耗统计**：监听本机会话事件，每轮对话结束后弹出本轮消耗金额（精确 usage，非估算）
   - 菜单可开关「每轮对话后自动显示消耗金额」；「自动关闭时间」可自定义秒数（填 0 表示不自动关闭）
   - 消耗金额泡泡显示期间，余额变动不弹普通泡泡
-- 💰 **投喂（内置充值）**：余额不足不用再手动去官网——菜单里左侧「投喂」按钮 + 右侧自定义金额（默认 ¥10，范围 ¥1–¥100000），点击后在菜单面板内展示微信 / 支付宝均可扫码支付的银联聚合码（右上角可返回），支付成功自动刷新余额并弹「已到账」气泡
-  - 余额低于平台预警阈值时鲸鱼会主动弹出「余额不足啦」提示，点气泡直接打开菜单；阈值与开关实时读取自平台 `users/current` 的 `balance_alert.CNY`（`enabled` / `alert_bound`），未配置平台令牌则不提示
-  - 复刻官网 top_up 页同一套充值接口，凭据复用 `DEEPSEEK_PLATFORM_TOKEN`，二维码本地生成、支付链接不外发
+- 💰 **投喂（余额充值）**：填入平台会话令牌后，点击「投喂」按钮，将展示微信 / 支付宝均可扫码支付的银联聚合码，支付成功自动刷新余额并提示
+  - 余额低于平台预警阈值时自动提示，提示阈值与开关来自平台的用户设置
+  - 直接调用官网同一套充值接口，不是“中转充值”
 - 🖱️ **拖拽 + 四边四分之一吸附**（左/右/上/下，角落可组合）
 - 🔄 左吸附时整体**水平镜像翻转**（文字同步反向、带动画）
 - 🧸 **按压 Q 弹**玩偶效果（按压时底部坐标不变）
@@ -34,7 +34,7 @@ dsh-whale-widget/
 ├── cordis.patch.yml      # 插件挂载声明
 ├── lib/
 │   ├── index.js          # 宿主侧插件本体
-│   └── qrcode-generator.js # 内嵌二维码编码库（MIT，Kazuhiko Arase；由 /dsh-whale/qrlib.js 原样伺服给前端渲染充值码）
+│   └── qrcode-generator.js # 内嵌二维码编码库（MIT，Kazuhiko Arase）
 ├── assets/
 │   ├── DSH2.png          # README 顶部展示图
 │   ├── DSniang1.png      # 小鲸鱼本体（cut-out，气泡由代码绘制）
@@ -101,7 +101,7 @@ dsh plugin --profile web add dsh-whale-widget
 
 > **默认不需要任何令牌。** 安装后只需配置 `DEEPSEEK_API_KEY`（拉取余额必需），「今日已用」会自动使用默认的**小鲸鱼记账**模式（余额差值本地记账），开箱即用。
 >
-> 「实时·令牌」用量模式和「投喂」充值功能需要 `DEEPSEEK_PLATFORM_TOKEN`（DeepSeek 平台网页会话令牌）。它是**可选的**：不配置时仅「实时·令牌」用量换算与「投喂」充值不可用，其余功能不受影响。获取方式见下方「用量模式使用教程」与「投喂使用教程」。
+> 「实时·令牌」用量模式和「投喂」充值功能需要 `DEEPSEEK_PLATFORM_TOKEN`（DeepSeek 平台网页会话令牌）。它是**可选的**：不配置时仅「实时·令牌」用量换算与「投喂」充值不可用，其余功能不受影响。获取方式见下方「用量模式使用教程」。
 
 ## 卸载
 
@@ -181,25 +181,6 @@ Remove-Item "$web\DSniang02.png" -ErrorAction SilentlyContinue
 
 「每轮对话消耗统计」直接监听 DSH 本机会话事件，按模型真实 usage 换算金额（与今日已用同一套峰谷定价表），**不需要** `DEEPSEEK_PLATFORM_TOKEN`。
 
-### 投喂（充值）使用教程 —— 需要 `DEEPSEEK_PLATFORM_TOKEN`
-
-余额不足时不用再手动打开官网：挂件内置了官网 top_up 页的充值流程，生成**微信 / 支付宝扫码均可支付**的银联聚合码。
-
-**使用步骤：**
-1. 配置 `DEEPSEEK_PLATFORM_TOKEN`（获取方式同上，两者共用同一个令牌）
-2. 打开挂件**菜单**：左侧「投喂」按钮 + 右侧金额输入框（默认 ¥10，范围 **¥1 – ¥100000**）
-3. 点「投喂」→ 弹出充值二维码（15 分钟有效），用微信或支付宝 App 扫码付款
-4. 支付成功后弹窗自动关闭，余额自动刷新并弹出「已到账」气泡；若余额接口有延迟，60 秒内自动刷新到位
-
-**余额过低提醒：** 余额低于**平台预警阈值**时鲸鱼会弹出「余额不足啦」气泡，点击气泡直接打开菜单（每 10 分钟最多提示一次）。阈值与开关实时读取平台 `users/current` 返回的 `balance_alert.CNY`：`enabled` 为预警开关、`alert_bound` 为阈值金额，在官网「账户设置」里修改即可；未配置 `DEEPSEEK_PLATFORM_TOKEN` 时不提示。
-
-**说明：**
-- ⚠️ **非官方文档化接口**：复刻的是官网前端调用的内部接口（`POST /api/v1/payments` + 每 5 秒轮询 `capture`）。DeepSeek 可能调整接口或临时暂停充值，失败时提示里会附「去官网充值」链接兜底
-- **二维码纯本地生成**（内嵌 qrcode-generator，MIT），支付链接不会发送给任何第三方
-- 仅支持 **CNY（人民币）** 账户；美元账户走信用卡/Apple Pay/Google Pay 等通道，不在本功能范围
-- 款项由扫码者直接支付给 DeepSeek 官方平台，挂件不接触任何资金
-- 令牌失效（如重新登录平台后）会提示重新获取；重复点击「投喂」有防抖保护，不会重复下单
-
 ## 验证
 
 ```powershell
@@ -209,17 +190,14 @@ curl http://127.0.0.1:3080/dsh-whale/image.png
 curl http://127.0.0.1:3080/dsh-whale/balance.json
 curl http://127.0.0.1:3080/dsh-whale/size.json
 curl http://127.0.0.1:3080/dsh-whale/last-turn.json
-curl http://127.0.0.1:3080/dsh-whale/qrlib.js
 curl -X POST http://127.0.0.1:3080/dsh-whale/topup.json -H "Content-Type: application/json" -d '{"amount":10}'
-curl -X POST http://127.0.0.1:3080/dsh-whale/topup-poll.json -H "Content-Type: application/json" -d '{"orderId":"<payment_order_id>"}'
 ```
 
 - `/dsh-whale/image.png` → 200 `image/png`
 - `/dsh-whale/balance.json` → 200，含 `{"ok":true,"totalBalance":...,"currency":"CNY","todayUsage":...}`
 - `/dsh-whale/size.json` → GET 返回配置；PUT 写入
 - `/dsh-whale/last-turn.json` → 200，含最近一轮对话消耗 `{seq, turn, amount, tokens}`
-- `/dsh-whale/qrlib.js` → 200 `application/javascript`（qrcode-generator 源码）
-- `/dsh-whale/topup.json` POST → 200，返回 `{ok, paymentOrderId, qrUrl, amount}`；`topup-poll.json` → 200，返回 `{ok, status}`
+- `/dsh-whale/topup.json` POST → 200，返回 `{ok, paymentOrderId, qrUrl, amount}`
 - 浏览器 F5 后右下角出现挂件
 
 ## 常见问题
@@ -229,9 +207,7 @@ curl -X POST http://127.0.0.1:3080/dsh-whale/topup-poll.json -H "Content-Type: a
 - **余额报「未配置 DEEPSEEK_API_KEY」**：去 DSH 配置凭据。
 - **今日已用显示 --**：记账模式下需要先跑一次余额观测（60 秒内自动完成）；令牌模式需要配置 `DEEPSEEK_PLATFORM_TOKEN`。
 - **每轮消耗不显示**：确认菜单「每轮对话后自动显示消耗金额」已勾选；一轮对话必须完整结束（turn/end）才会结算。
-- **投喂提示「未配置平台令牌」**：需要配置 `DEEPSEEK_PLATFORM_TOKEN`（见「投喂使用教程」）；重新登录平台网页后令牌可能失效，需重新获取。
-- **投喂二维码不显示**：确认 `lib/qrcode-generator.js` 在插件包内且 `/dsh-whale/qrlib.js` 可访问（重启 `dsh web` 后 F5）。
-- **投喂后余额没变**：必须扫码完成支付才会入账；到账后余额自动刷新，若余额接口延迟 60 秒内也会自动刷新到位。
+- **投喂功能不可用**：去 DSH 配置凭据。
 - **没有声音**：确认 `assets/*.mp3` 在包内；若不想带音效文件，静默降级为无声音。
 - **本地开发改了代码不生效**：使用 `link:` 安装时，修改源码后重启 `dsh web`（ESM 模块缓存）；如果用已发布版本，需要 `npm publish` 新版本后 `dsh plugin --profile web update dsh-whale-widget`。
 - **自定义图片**：气泡由代码绘制（SVG），鲸鱼本体为 cut-out PNG，放在右下角 59.45%；换图需保证透明背景 cut-out，否则按 `whale-widget-prompt.md` 调整几何参数。

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ DeepSeek Harness（DSH）Web 界面右下角的常驻余额挂件：小鲸鱼气
 - 💬 **每轮对话消耗统计**：监听本机会话事件，每轮对话结束后弹出本轮消耗金额（精确 usage，非估算）
   - 菜单可开关「每轮对话后自动显示消耗金额」；「自动关闭时间」可自定义秒数（填 0 表示不自动关闭）
   - 消耗金额泡泡显示期间，余额变动不弹普通泡泡
+- 💰 **投喂（内置充值）**：余额不足不用再手动去官网——菜单里左侧「投喂」按钮 + 右侧自定义金额（默认 ¥10，范围 ¥1–¥100000），点击后在菜单面板内展示微信 / 支付宝均可扫码支付的银联聚合码（右上角可返回），支付成功自动刷新余额并弹「已到账」气泡
+  - 余额低于平台预警阈值时鲸鱼会主动弹出「余额不足啦」提示，点气泡直接打开菜单；阈值与开关实时读取自平台 `users/current` 的 `balance_alert.CNY`（`enabled` / `alert_bound`），未配置平台令牌则不提示
+  - 复刻官网 top_up 页同一套充值接口，凭据复用 `DEEPSEEK_PLATFORM_TOKEN`，二维码本地生成、支付链接不外发
 - 🖱️ **拖拽 + 四边四分之一吸附**（左/右/上/下，角落可组合）
 - 🔄 左吸附时整体**水平镜像翻转**（文字同步反向、带动画）
 - 🧸 **按压 Q 弹**玩偶效果（按压时底部坐标不变）
@@ -30,7 +33,8 @@ dsh-whale-widget/
 ├── README.md             # 本文件
 ├── cordis.patch.yml      # 插件挂载声明
 ├── lib/
-│   └── index.js          # 宿主侧插件本体
+│   ├── index.js          # 宿主侧插件本体
+│   └── qrcode-generator.js # 内嵌二维码编码库（MIT，Kazuhiko Arase；由 /dsh-whale/qrlib.js 原样伺服给前端渲染充值码）
 ├── assets/
 │   ├── DSH2.png          # README 顶部展示图
 │   ├── DSniang1.png      # 小鲸鱼本体（cut-out，气泡由代码绘制）
@@ -81,7 +85,7 @@ dsh plugin --profile web add dsh-whale-widget
 
 > **默认不需要任何令牌。** 安装后只需配置 `DEEPSEEK_API_KEY`（拉取余额必需），「今日已用」会自动使用默认的**小鲸鱼记账**模式（余额差值本地记账），开箱即用。
 >
-> 「实时·令牌」模式用到的 `DEEPSEEK_PLATFORM_TOKEN`（DeepSeek 平台网页会话令牌）是**可选的**，仅在你想要更精确的实时用量换算时才需要配置。获取方式见下方「用量模式使用教程」。
+> 「实时·令牌」用量模式和「投喂」充值功能需要 `DEEPSEEK_PLATFORM_TOKEN`（DeepSeek 平台网页会话令牌）。它是**可选的**：不配置时仅「实时·令牌」用量换算与「投喂」充值不可用，其余功能不受影响。获取方式见下方「用量模式使用教程」与「投喂使用教程」。
 
 ## 卸载
 
@@ -161,6 +165,25 @@ Remove-Item "$web\DSniang02.png" -ErrorAction SilentlyContinue
 
 「每轮对话消耗统计」直接监听 DSH 本机会话事件，按模型真实 usage 换算金额（与今日已用同一套峰谷定价表），**不需要** `DEEPSEEK_PLATFORM_TOKEN`。
 
+### 投喂（充值）使用教程 —— 需要 `DEEPSEEK_PLATFORM_TOKEN`
+
+余额不足时不用再手动打开官网：挂件内置了官网 top_up 页的充值流程，生成**微信 / 支付宝扫码均可支付**的银联聚合码。
+
+**使用步骤：**
+1. 配置 `DEEPSEEK_PLATFORM_TOKEN`（获取方式同上，两者共用同一个令牌）
+2. 打开挂件**菜单**：左侧「投喂」按钮 + 右侧金额输入框（默认 ¥10，范围 **¥1 – ¥100000**）
+3. 点「投喂」→ 弹出充值二维码（15 分钟有效），用微信或支付宝 App 扫码付款
+4. 支付成功后弹窗自动关闭，余额自动刷新并弹出「已到账」气泡；若余额接口有延迟，60 秒内自动刷新到位
+
+**余额过低提醒：** 余额低于**平台预警阈值**时鲸鱼会弹出「余额不足啦」气泡，点击气泡直接打开菜单（每 10 分钟最多提示一次）。阈值与开关实时读取平台 `users/current` 返回的 `balance_alert.CNY`：`enabled` 为预警开关、`alert_bound` 为阈值金额，在官网「账户设置」里修改即可；未配置 `DEEPSEEK_PLATFORM_TOKEN` 时不提示。
+
+**说明：**
+- ⚠️ **非官方文档化接口**：复刻的是官网前端调用的内部接口（`POST /api/v1/payments` + 每 5 秒轮询 `capture`）。DeepSeek 可能调整接口或临时暂停充值，失败时提示里会附「去官网充值」链接兜底
+- **二维码纯本地生成**（内嵌 qrcode-generator，MIT），支付链接不会发送给任何第三方
+- 仅支持 **CNY（人民币）** 账户；美元账户走信用卡/Apple Pay/Google Pay 等通道，不在本功能范围
+- 款项由扫码者直接支付给 DeepSeek 官方平台，挂件不接触任何资金
+- 令牌失效（如重新登录平台后）会提示重新获取；重复点击「投喂」有防抖保护，不会重复下单
+
 ## 验证
 
 ```powershell
@@ -170,12 +193,17 @@ curl http://127.0.0.1:3080/dsh-whale/image.png
 curl http://127.0.0.1:3080/dsh-whale/balance.json
 curl http://127.0.0.1:3080/dsh-whale/size.json
 curl http://127.0.0.1:3080/dsh-whale/last-turn.json
+curl http://127.0.0.1:3080/dsh-whale/qrlib.js
+curl -X POST http://127.0.0.1:3080/dsh-whale/topup.json -H "Content-Type: application/json" -d '{"amount":10}'
+curl -X POST http://127.0.0.1:3080/dsh-whale/topup-poll.json -H "Content-Type: application/json" -d '{"orderId":"<payment_order_id>"}'
 ```
 
 - `/dsh-whale/image.png` → 200 `image/png`
 - `/dsh-whale/balance.json` → 200，含 `{"ok":true,"totalBalance":...,"currency":"CNY","todayUsage":...}`
 - `/dsh-whale/size.json` → GET 返回配置；PUT 写入
 - `/dsh-whale/last-turn.json` → 200，含最近一轮对话消耗 `{seq, turn, amount, tokens}`
+- `/dsh-whale/qrlib.js` → 200 `application/javascript`（qrcode-generator 源码）
+- `/dsh-whale/topup.json` POST → 200，返回 `{ok, paymentOrderId, qrUrl, amount}`；`topup-poll.json` → 200，返回 `{ok, status}`
 - 浏览器 F5 后右下角出现挂件
 
 ## 常见问题
@@ -185,6 +213,9 @@ curl http://127.0.0.1:3080/dsh-whale/last-turn.json
 - **余额报「未配置 DEEPSEEK_API_KEY」**：去 DSH 配置凭据。
 - **今日已用显示 --**：记账模式下需要先跑一次余额观测（60 秒内自动完成）；令牌模式需要配置 `DEEPSEEK_PLATFORM_TOKEN`。
 - **每轮消耗不显示**：确认菜单「每轮对话后自动显示消耗金额」已勾选；一轮对话必须完整结束（turn/end）才会结算。
+- **投喂提示「未配置平台令牌」**：需要配置 `DEEPSEEK_PLATFORM_TOKEN`（见「投喂使用教程」）；重新登录平台网页后令牌可能失效，需重新获取。
+- **投喂二维码不显示**：确认 `lib/qrcode-generator.js` 在插件包内且 `/dsh-whale/qrlib.js` 可访问（重启 `dsh web` 后 F5）。
+- **投喂后余额没变**：必须扫码完成支付才会入账；到账后余额自动刷新，若余额接口延迟 60 秒内也会自动刷新到位。
 - **没有声音**：确认 `assets/*.mp3` 在包内；若不想带音效文件，静默降级为无声音。
 - **本地开发改了代码不生效**：使用 `link:` 安装时，修改源码后重启 `dsh web`（ESM 模块缓存）；如果用已发布版本，需要 `npm publish` 新版本后 `dsh plugin --profile web update dsh-whale-widget`。
 - **自定义图片**：气泡由代码绘制（SVG），鲸鱼本体为 cut-out PNG，放在右下角 59.45%；换图需保证透明背景 cut-out，否则按 `whale-widget-prompt.md` 调整几何参数。

--- a/lib/index.js
+++ b/lib/index.js
@@ -1687,7 +1687,6 @@ fetch(SIZE_URL, { cache: 'no-store' })
     // 恢复时还原吸附状态（hAnchor/vAnchor → state.h/v），避免挂件变自由位置
     // 导致避让调节不实时（settle 自由分支只 clamp 不重算位置）。
     try {
-    try {
       var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
       if (a && a.v === 2 && (a.hAnchor === 'left' || a.hAnchor === 'right') && typeof a.hDist === 'number' &&
           (a.vAnchor === 'top' || a.vAnchor === 'bottom') && typeof a.vDist === 'number') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -978,7 +978,7 @@ function showTopUpBubble(text) {
   lowHintArmed = false
   applyBubbleLines([
     { t: '谢谢投喂！', s: 'A', c: '' },
-    { t: text, s: 'B', c: '#e0433f' },
+    { t: text, s: 'B', c: '#2fa24c' },
   ])
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
 
 // Package root: lib/index.js -> package root. Keeps the bundle relocatable
 // when installed as a normal DSH npm plugin (node_modules or a local link).
@@ -57,6 +58,13 @@ function soundSetFromUrl(url) {
 }
 const BALANCE_URL = 'https://api.deepseek.com/user/balance'
 const BALANCE_TTL_MS = 25000
+// 投喂：DeepSeek 平台充值（与官网 top_up 页同一套内部接口，走 CMB_UNIONPAY 银联聚合码，
+// 微信/支付宝扫码均可支付；凭据复用 DEEPSEEK_PLATFORM_TOKEN 平台会话令牌）
+const PLATFORM_API = 'https://platform.deepseek.com'
+const TOPUP_MIN_CNY = 1
+const TOPUP_MAX_CNY = 100000
+// 内嵌的 qrcode-generator（MIT, Kazuhiko Arase）源码，经 /dsh-whale/qrlib.js 原样伺服
+const QRLIB_FILE = path.join(PACKAGE_ROOT, 'lib', 'qrcode-generator.js')
 const RUA_GIF_CANDIDATES = [
   path.join(PACKAGE_ROOT, 'assets', 'rua.gif'),
   'D:/TestBox/deepseek/skin/rua.gif',
@@ -117,6 +125,13 @@ var BALANCE_URL = '/dsh-whale/balance.json'
 var SIZE_URL = '/dsh-whale/size.json'
 var IMG_URL = '/dsh-whale/image.png?v=2'
 var GIF_URL = '/dsh-whale/rua.gif'
+var TOPUP_URL = '/dsh-whale/topup.json'
+var TOPUP_POLL_URL = '/dsh-whale/topup-poll.json'
+var TOPUP_POLL_MS = 5000
+var TOPUP_EXPIRE_MS = 15 * 60 * 1000
+var ALERT_URL = '/dsh-whale/alert.json'
+var ALERT_REFRESH_MS = 5 * 60 * 1000
+var LOW_HINT_COOLDOWN_MS = 10 * 60 * 1000
 
 var css = [
   '.dshwv-root{position:fixed;right:0;bottom:0;--dshw-scale:1;--dshw-base:clamp(122px,calc(min(250px,min(100vw,100vh) * 0.28) * var(--dshw-scale)),625px);width:var(--dshw-base);height:var(--dshw-base);pointer-events:none;user-select:none;-webkit-user-select:none;z-index:9999;font-family:inherit;transition:left .16s ease,top .16s ease,transform .3s ease}',
@@ -160,7 +175,23 @@ var css = [
   '.dshwv-sound:hover{background:rgba(32,49,112,.16)}',
   '.dshwv-check{width:16px;height:16px;accent-color:#203170;cursor:pointer;flex:0 0 auto}',
   '.dshwv-menu-sep{height:1px;background:rgba(32,49,112,.25);margin:6px 0}',
-  '.dshwv-volpct{width:36px;text-align:right;color:#203170;font-size:12px}'
+  '.dshwv-volpct{width:36px;text-align:right;color:#203170;font-size:12px}',
+  '.dshwv-topup-menu-btn{flex:1;min-width:0;border:none;border-radius:8px;padding:7px 0;background:#203170;color:#fff;font-size:12px;font-weight:600;cursor:pointer}',
+  '.dshwv-topup-menu-btn:hover{background:#2c3f8f}',
+  '.dshwv-topup-menu-btn:disabled{opacity:.55;cursor:not-allowed}',
+  '.dshwv-topup-menu-btn.dshwv-topup-menu-missing{opacity:.5;background:#8a97c4}',
+  '.dshwv-menu-qr > .dshwv-menu-row,.dshwv-menu-qr > .dshwv-menu-sep,.dshwv-menu-qr > .dshwv-topup-err{display:none}',
+  '.dshwv-topup-qr-panel{display:none;flex-direction:column;align-items:center;padding:34px 8px 8px;color:#203170;color-scheme:light}',
+  '.dshwv-menu-qr > .dshwv-topup-qr-panel{display:flex}',
+  '.dshwv-topup-back{position:absolute;top:8px;right:10px;width:26px;height:26px;border:none;background:transparent;color:#203170;display:flex;align-items:center;justify-content:center;padding:0;cursor:pointer}',
+  '.dshwv-topup-back:hover{opacity:.7}',
+  '.dshwv-topup-back svg{display:block}',
+  '.dshwv-topup-loading{font-size:12px;color:#7c8cc0;text-align:center}',
+  '.dshwv-topup-qr-panel svg{width:min(190px,calc(100vw - 84px));height:auto;image-rendering:pixelated}',
+  '.dshwv-topup-qr-hint{font-size:12px;color:#203170;margin-top:10px}',
+  '.dshwv-topup-qr-amount{font-size:15px;font-weight:800;color:#e0433f;margin-top:4px}',
+  '.dshwv-topup-qr-count{font-size:11px;color:#7c8cc0;margin-top:4px}',
+  '.dshwv-topup-err{font-size:11px;color:#e0433f;margin-top:10px;line-height:1.5;display:none;white-space:normal;text-align:center}'
 ].join('\\n')
 
 var styleEl = document.createElement('style')
@@ -260,6 +291,48 @@ turnCostCloseInput.className = 'dshwv-number'
 turnCostCloseInput.value = '5'
 turnCostCloseInput.title = '填 0 表示不自动关闭，需手动点击关闭'
 turnCostCloseInput.addEventListener('change', function () { setTurnCostClose(turnCostCloseInput.value) })
+var rowTopup = menuRow()
+var topupBtn = document.createElement('button')
+topupBtn.type = 'button'
+topupBtn.className = 'dshwv-topup-menu-btn'
+topupBtn.textContent = '投喂'
+topupBtn.title = '给 DeepSeek 平台账户充值（微信/支付宝扫码，款项直达官方）'
+topupBtn.addEventListener('click', function () { topupFeed() })
+var topupAmountInput = document.createElement('input')
+topupAmountInput.type = 'number'
+topupAmountInput.min = '1'
+topupAmountInput.max = '100000'
+topupAmountInput.step = '1'
+topupAmountInput.value = '10'
+topupAmountInput.className = 'dshwv-number'
+topupAmountInput.title = '自定义金额（¥1 – ¥100000，整数）'
+topupAmountInput.addEventListener('keydown', function (e) {
+  if (e.key === 'Enter') { e.preventDefault(); topupFeed(); return }
+  // 只允许整数：屏蔽小数点与科学计数符号
+  if (e.key === '.' || e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
+    e.preventDefault()
+  }
+})
+topupAmountInput.addEventListener('input', function () {
+  // 兜底（粘贴等路径）：只保留整数部分
+  var v = topupAmountInput.value
+  if (v === '' || v === '-') return
+  if (/[.eE]/.test(v)) {
+    var n = parseInt(v, 10)
+    topupAmountInput.value = isFinite(n) ? String(n) : ''
+  }
+})
+topupAmountInput.addEventListener('change', function () {
+  var n = Math.round(Number(topupAmountInput.value))
+  if (!isFinite(n)) n = 10
+  n = clamp(n, 1, 100000)
+  topupAmountInput.value = String(n)
+  saveConfig()
+})
+rowTopup.appendChild(topupBtn)
+rowTopup.appendChild(topupAmountInput)
+var topupMenuErr = document.createElement('div')
+topupMenuErr.className = 'dshwv-topup-err'
 var row1 = menuRow()
 row1.appendChild(menuLabel('大小'))
 row1.appendChild(scaleInput)
@@ -300,6 +373,8 @@ var row8 = menuRow()
 row8.appendChild(menuLabel('自动关闭时间'))
 row8.appendChild(turnCostCloseInput)
 row8.appendChild(menuLabel('秒'))
+menuBox.appendChild(rowTopup)
+menuBox.appendChild(topupMenuErr)
 menuBox.appendChild(row1)
 menuBox.appendChild(row2)
 menuBox.appendChild(row3)
@@ -345,6 +420,13 @@ bubbleBox.addEventListener('click', function (e) {
   if (costBubbleActive) {
     // 消耗金额泡泡：点击关闭（确认）
     hideCostBubble()
+    return
+  }
+  if (lowHintArmed) {
+    // 余额过低提示泡泡：点击打开菜单（投喂入口在菜单里）
+    lowHintArmed = false
+    hideBubble()
+    if (!menuOpen) toggleMenu()
     return
   }
   if (bubbleRandomActive) {
@@ -540,6 +622,7 @@ function showBubble() {
   if (gifFadeTimer) { clearTimeout(gifFadeTimer); gifFadeTimer = null }
   bubbleShown = true
   bubbleRandomActive = false
+  lowHintArmed = false
   restoreBubbleLines()
   bubbleBox.classList.add('dshwv-bubble-open')
   // 默认展示当前内容；点击气泡切到随机台词段；总时长 5 秒自动关闭
@@ -555,6 +638,7 @@ function hideBubble() {
   hintEl.style.opacity = ''
   bubbleRandomActive = false
   bubbleRandomLines = null
+  lowHintArmed = false
   bubbleShown = false
   // 只销毁 gif 显示；三行文字保持现状让气泡自然淡出——不能在关闭瞬间
   // 恢复成余额内容（否则随机台词界面会闪现余额）。文字恢复交给下次
@@ -603,6 +687,265 @@ function hideCostBubble() {
   if (costBubbleTimer) { clearTimeout(costBubbleTimer); costBubbleTimer = null }
   costBubbleActive = false
   hideBubble()
+}
+
+// —— 投喂（DeepSeek 平台充值，微信/支付宝扫码，款项直达官方账户）——
+var lowHintArmed = false
+var lastLowHintTs = 0
+// 低余额预警阈值来自平台 users/current 的 balance_alert.CNY（enabled 开关 + alert_bound 阈值）
+var alertConfig = null
+var alertFetching = false
+// 平台令牌可用状态：'unknown' | 'ok' | 'missing' | 'expired'；用于投喂按钮的视觉提示
+var tokenState = 'unknown'
+function applyTokenState() {
+  if (tokenState === 'missing') {
+    topupBtn.classList.add('dshwv-topup-menu-missing')
+    topupBtn.title = '需要配置令牌（如何配置：去问dsh）'
+  } else if (tokenState === 'expired') {
+    topupBtn.classList.add('dshwv-topup-menu-missing')
+    topupBtn.title = 'DEEPSEEK_PLATFORM_TOKEN 已失效，请重新获取'
+  } else {
+    topupBtn.classList.remove('dshwv-topup-menu-missing')
+    topupBtn.title = '给 DeepSeek 平台账户充值（微信/支付宝扫码，款项直达官方）'
+  }
+}
+function refreshAlertConfig() {
+  if (alertFetching) return
+  alertFetching = true
+  fetch(ALERT_URL, { cache: 'no-store' })
+    .then(function (r) { return r.json() })
+    .then(function (d) {
+      if (d && d.ok && typeof d.enabled === 'boolean') {
+        alertConfig = { enabled: d.enabled, alertBound: isFinite(Number(d.alertBound)) ? Number(d.alertBound) : null }
+        tokenState = 'ok'
+      } else if (d && d.code === 'NO_TOKEN') {
+        // 未配置平台令牌：不提示（投喂功能会给出对应错误引导）
+        alertConfig = { enabled: false, alertBound: null }
+        tokenState = 'missing'
+      } else if (d && d.code === 'TOKEN_EXPIRED') {
+        // 令牌失效：服务端已清除本地令牌，按未配置处理
+        alertConfig = { enabled: false, alertBound: null }
+        tokenState = 'missing'
+      }
+      applyTokenState()
+    })
+    .catch(function () {})
+    .finally(function () { alertFetching = false })
+}
+function maybeLowBalanceHint(balance) {
+  if (!bubbleOn) return
+  if (balance === null || !isFinite(Number(balance))) return
+  if (!alertConfig) {
+    refreshAlertConfig()
+    return
+  }
+  if (alertConfig.enabled === false || alertConfig.alertBound === null) return
+  if (Number(balance) >= alertConfig.alertBound) return
+  var now = Date.now()
+  if (now - lastLowHintTs < LOW_HINT_COOLDOWN_MS) return
+  lastLowHintTs = now
+  // 延迟一点展示，避免与余额加载/变化动画同时进行
+  setTimeout(function () {
+    if (!bubbleShown) showLowBubble(Number(balance))
+  }, 500)
+}
+function showLowBubble(balance) {
+  if (!bubbleOn || costBubbleActive) return
+  showBubble()
+  lowHintArmed = true
+  applyBubbleLines([
+    { t: '余额不足啦', s: 'A', c: '' },
+    { t: fmt(balance, state.currency), s: 'B', c: '#e0433f' },
+  ])
+}
+
+var topupQrPanel = document.createElement('div')
+topupQrPanel.className = 'dshwv-topup-qr-panel'
+var topupBackBtn = document.createElement('button')
+topupBackBtn.type = 'button'
+topupBackBtn.className = 'dshwv-topup-back'
+topupBackBtn.title = '返回'
+topupBackBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.16431 2.61472C4.54663 2.61472 4.12849 2.61472 3.80689 2.64304C3.49453 2.67059 3.33992 2.72098 3.23462 2.77976C3.02427 2.8972 2.8501 3.07037 2.73267 3.28073C2.67391 3.38605 2.62447 3.5406 2.59693 3.853C2.56857 4.17462 2.56763 4.59259 2.56763 5.21042L2.56763 10.7895C2.56763 11.4073 2.56858 11.8253 2.59693 12.1469C2.62447 12.4594 2.67391 12.6139 2.73267 12.7192C2.85009 12.9296 3.02427 13.1027 3.23462 13.2202C3.33992 13.279 3.49453 13.3294 3.80689 13.3569C4.12849 13.3852 4.54663 13.3852 5.16431 13.3852V14.7856C4.57152 14.7856 4.08118 14.7864 3.68384 14.7514C3.27727 14.7156 2.90099 14.6376 2.552 14.4428C2.11505 14.1989 1.75391 13.8378 1.51001 13.4009C1.31546 13.052 1.23822 12.6764 1.20239 12.27C1.16737 11.8726 1.16821 11.3824 1.16821 10.7895L1.16821 5.21042C1.16821 4.61757 1.16737 4.1273 1.20239 3.72995C1.23823 3.32357 1.31545 2.94794 1.51001 2.59909C1.75392 2.16208 2.11504 1.80107 2.552 1.5571C2.90099 1.36233 3.27727 1.28436 3.68384 1.24851C4.08118 1.2135 4.57152 1.21433 5.16431 1.21433L5.16431 2.61472Z" fill="currentColor"></path><path d="M14.8108 7.73386C14.8387 7.91002 14.8387 8.08992 14.8108 8.26608C14.7585 8.59621 14.5984 8.85544 14.4221 9.07468C14.2539 9.28369 14.0228 9.51404 13.7688 9.76804L10.4768 13.0591L9.48657 12.0688L12.7786 8.7778C12.8052 8.75114 12.831 8.72537 12.8557 8.70065H4.91138V7.30026H12.8567C12.8317 7.2752 12.8056 7.2492 12.7786 7.22214L9.48657 3.93112L10.4768 2.94089L13.7688 6.2319C14.0229 6.48602 14.2539 6.71617 14.4221 6.92526C14.5985 7.14451 14.7584 7.40371 14.8108 7.73386Z" fill="currentColor"></path></svg>'
+topupBackBtn.addEventListener('click', topupHideQr)
+var topupQrHolder = document.createElement('div')
+topupQrHolder.className = 'dshwv-topup-loading'
+topupQrHolder.textContent = '二维码生成中…'
+var topupQrHint = document.createElement('div')
+topupQrHint.className = 'dshwv-topup-qr-hint'
+topupQrHint.textContent = '支持微信 / 支付宝扫码支付'
+var topupQrAmount = document.createElement('div')
+topupQrAmount.className = 'dshwv-topup-qr-amount'
+var topupQrCount = document.createElement('div')
+topupQrCount.className = 'dshwv-topup-qr-count'
+var topupQrErr = document.createElement('div')
+topupQrErr.className = 'dshwv-topup-err'
+topupQrPanel.appendChild(topupBackBtn)
+topupQrPanel.appendChild(topupQrHolder)
+topupQrPanel.appendChild(topupQrHint)
+topupQrPanel.appendChild(topupQrAmount)
+topupQrPanel.appendChild(topupQrCount)
+topupQrPanel.appendChild(topupQrErr)
+menuBox.appendChild(topupQrPanel)
+
+var topupPollTimer = null
+var topupCountTimer = null
+var topupExpireAt = 0
+var topupPaidAmount = ''
+var topupCreating = false
+
+function topupShowErr(box, text) {
+  box.textContent = text || ''
+  box.style.display = text ? 'block' : 'none'
+}
+function topupMenuErrWithOfficial(text) {
+  // 仅显示错误文案，不再附「去官网充值」链接
+  topupShowErr(topupMenuErr, text)
+}
+function topupStop() {
+  if (topupPollTimer) { clearInterval(topupPollTimer); topupPollTimer = null }
+  if (topupCountTimer) { clearInterval(topupCountTimer); topupCountTimer = null }
+}
+function topupHideQr() {
+  topupStop()
+  menuBox.classList.remove('dshwv-menu-qr')
+  topupQrHolder.innerHTML = ''
+  topupQrHolder.textContent = '二维码生成中…'
+  topupQrAmount.textContent = ''
+  topupQrCount.textContent = ''
+  topupShowErr(topupQrErr, '')
+  positionMenu()
+}
+function renderQrSvg(text) {
+  try {
+    var QR = window.qrcode || null
+    if (!QR || typeof QR !== 'function') return null
+    var q = QR(0, 'M')
+    q.addData(String(text))
+    q.make()
+    return q.createSvgTag({ cellSize: 4, margin: 8, scalable: true })
+  } catch (err) { return null }
+}
+function topupFeed() {
+  if (topupCreating) return
+  var amt = Math.round(Number(topupAmountInput.value))
+  if (!isFinite(amt) || amt < 1 || amt > 100000) {
+    topupShowErr(topupMenuErr, '金额需在 ¥1 – ¥100000 之间')
+    return
+  }
+  topupShowErr(topupMenuErr, '')
+  topupCreating = true
+  topupBtn.disabled = true
+  topupBtn.textContent = '生成中…'
+  fetch(TOPUP_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ amount: amt }) })
+    .then(function (r) { return r.json() })
+    .then(function (d) {
+      if (!d || !d.ok) {
+        var code = d && d.code ? d.code : 'ERROR'
+        var msg = d && d.error ? String(d.error) : '生成失败'
+        if (code === 'NO_TOKEN') {
+          // 未配置令牌：按钮已变灰 + tooltip「需要配置令牌」，不再弹错误文案
+          tokenState = 'missing'; applyTokenState()
+          return
+        } else if (code === 'TOKEN_EXPIRED') {
+          // 服务端已检测到令牌失效并清除本地令牌，显示干净提示并置灰
+          tokenState = 'missing'; applyTokenState()
+          topupMenuErrWithOfficial(msg && msg.indexOf('令牌过期') !== -1 ? msg : '令牌过期，请重新获取')
+        } else {
+          topupMenuErrWithOfficial(msg + '。')
+        }
+        return
+      }
+      topupEnterQr(d)
+      // 投喂成功 = 令牌确证可用：把按钮状态复位为正常，并刷新预警配置
+      tokenState = 'ok'
+      applyTokenState()
+      refreshAlertConfig()
+    })
+    .catch(function () {
+      topupMenuErrWithOfficial('网络异常，生成失败。')
+    })
+    .finally(function () {
+      topupCreating = false
+      topupBtn.disabled = false
+      topupBtn.textContent = '投喂'
+    })
+}
+function topupEnterQr(d) {
+  topupShowErr(topupQrErr, '')
+  topupPaidAmount = isFinite(Number(d.amount)) ? Number(d.amount).toFixed(2) : ''
+  topupQrAmount.textContent = '支付金额 ¥' + (topupPaidAmount || '--')
+  topupExpireAt = Date.now() + TOPUP_EXPIRE_MS
+  // 纯本地生成二维码，支付链接绝不外发到任何第三方
+  var svg = renderQrSvg(d.qrUrl)
+  if (svg) {
+    topupQrHolder.innerHTML = svg
+  } else {
+    topupQrHolder.innerHTML = ''
+    topupQrHolder.textContent = '二维码加载失败，请刷新页面重试'
+  }
+  menuBox.classList.add('dshwv-menu-qr')
+  positionMenu()
+  startTopUpCountdown()
+  startTopUpPoll(d.paymentOrderId)
+}
+function startTopUpCountdown() {
+  if (topupCountTimer) { clearInterval(topupCountTimer); topupCountTimer = null }
+  function tick() {
+    var remain = topupExpireAt - Date.now()
+    if (remain <= 0) {
+      clearInterval(topupCountTimer); topupCountTimer = null
+      topupQrCount.textContent = '二维码已过期'
+      topupShowErr(topupQrErr, '二维码已过期，请返回后重新生成')
+      stopTopUpPoll()
+      return
+    }
+    var s = Math.floor(remain / 1000)
+    var m = Math.floor(s / 60)
+    var sec = s % 60
+    topupQrCount.textContent = '剩余 ' + m + ':' + (sec < 10 ? '0' : '') + sec
+  }
+  tick()
+  topupCountTimer = setInterval(tick, 1000)
+}
+function stopTopUpPoll() {
+  if (topupPollTimer) { clearInterval(topupPollTimer); topupPollTimer = null }
+}
+function startTopUpPoll(orderId) {
+  stopTopUpPoll()
+  topupPollTimer = setInterval(function () {
+    fetch(TOPUP_POLL_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ orderId: orderId }) })
+      .then(function (r) { return r.json() })
+      .then(function (d) {
+        if (!d || !d.ok) {
+          // 令牌失效/未配置等硬错误：停止轮询并提示；网络抖动则继续轮询
+          if (d && (d.code === 'TOKEN_EXPIRED' || d.code === 'NO_TOKEN')) {
+            stopTopUpPoll()
+            topupShowErr(topupQrErr, '轮询失败：' + ((d && d.error) || d.code))
+          }
+          return
+        }
+        if (d.status === 'SUCCESS') {
+          topupHideQr()
+          closeMenu()
+          Promise.resolve(refresh(true)).then(function () {
+            showTopUpBubble('¥' + topupPaidAmount + ' 已到账')
+          })
+        } else if (d.status === 'FAILED' || d.status === 'REFUNDED' || d.status === 'CHARGEBACK') {
+          stopTopUpPoll()
+          topupShowErr(topupQrErr, '支付未完成（' + d.status + '），可返回重新发起')
+        }
+      })
+      .catch(function () {})
+  }, TOPUP_POLL_MS)
+}
+function showTopUpBubble(text) {
+  if (!bubbleOn) return
+  showBubble()
+  lowHintArmed = false
+  applyBubbleLines([
+    { t: '谢谢投喂！', s: 'A', c: '' },
+    { t: text, s: 'B', c: '#e0433f' },
+  ])
 }
 
 function clamp(v, lo, hi) { return v < lo ? lo : (v > hi ? hi : v) }
@@ -705,7 +1048,7 @@ function settle() {
   express()
 }
 function refresh(manual) {
-  if (busy) return
+  if (busy) return null
   busy = true
   if (animDelayTimer) { clearTimeout(animDelayTimer); animDelayTimer = null }
   if (manual || state.balance === null) { state.status = 'loading'; render() }
@@ -715,7 +1058,7 @@ function refresh(manual) {
     ctrl = new AbortController()
     timer = setTimeout(function () { try { ctrl.abort() } catch (err) {} }, FETCH_TIMEOUT_MS)
   } catch (err) {}
-  fetch(BALANCE_URL, { cache: 'no-store', signal: ctrl ? ctrl.signal : undefined })
+  return fetch(BALANCE_URL, { cache: 'no-store', signal: ctrl ? ctrl.signal : undefined })
     .then(function (r) { return r.json() })
     .then(function (data) {
       if (data && data.ok) {
@@ -728,6 +1071,7 @@ function refresh(manual) {
         state.message = ''
         state.todayUsage = data.todayUsage !== undefined ? data.todayUsage : null
         state.isPeak = !!data.isPeak
+        maybeLowBalanceHint(nb)
         if (changed && !currencyChanged) {
           if (!manual) {
             showBubble()
@@ -780,7 +1124,7 @@ var turnCostCloseMs = 5000
 var costBubbleActive = false
 function saveConfig() {
   try {
-    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs }) })
+    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs, topupAmount: Math.min(100000, Math.max(1, Math.round(Number(topupAmountInput.value) || 10))) }) })
     var vp = viewport()
     var w = root.offsetWidth || root.getBoundingClientRect().width || 0
     var h = root.offsetHeight || root.getBoundingClientRect().height || 0
@@ -961,6 +1305,8 @@ function toggleMenu() {
 function closeMenu() {
   menuOpen = false
   menuBox.classList.remove('dshwv-menu-open')
+  menuBox.classList.remove('dshwv-menu-qr')
+  topupStop()
   root.style.transition = ''
   snapCheck()
 }
@@ -1064,6 +1410,8 @@ function onDocPointerDown(e) {
     if (e.target.closest('.dshwv-bubble') || e.target.closest('.dshwv-menu') || e.target.closest('.dshwv-menu-btn')) return
   }
   if (menuOpen) {
+    // 二维码展示时，禁止点击空白处关闭（二维码是菜单内的一部分，需用右上角返回图标退出）
+    if (menuBox.classList.contains('dshwv-menu-qr')) return
     closeMenu()
     return
   }
@@ -1195,6 +1543,7 @@ express()
 render()
 applySoundSet()
 setupHitTest()
+refreshAlertConfig()
 fetch(SIZE_URL, { cache: 'no-store' })
   .then(function (r) { return r.json() })
   .then(function (d) {
@@ -1240,6 +1589,9 @@ fetch(SIZE_URL, { cache: 'no-store' })
       turnCostCloseMs = d.turnCostCloseMs > 0 ? d.turnCostCloseMs : 0
       turnCostCloseInput.value = String(Math.round(turnCostCloseMs / 1000))
     }
+    if (d && typeof d.topupAmount === 'number') {
+      topupAmountInput.value = String(Math.min(100000, Math.max(1, Math.round(d.topupAmount))))
+    }
     // 相对边框恢复（localStorage 锚点）：窗口变化后保持离边距离
     try {
       var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
@@ -1261,6 +1613,7 @@ fetch(SIZE_URL, { cache: 'no-store' })
   })
   .catch(function () { refresh(false) })
 setInterval(function () { refresh(false) }, REFRESH_MS)
+setInterval(refreshAlertConfig, ALERT_REFRESH_MS)
 
 // —— 每轮对话消耗检测：轮询 last-turn.json，出现新 seq 时弹消耗金额泡泡 ——
 var LAST_TURN_URL = '/dsh-whale/last-turn.json'
@@ -1478,6 +1831,185 @@ function apply(ctx) {
       }
     }
 
+    function platformHeaders(token) {
+      return {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + token,
+        // 与官网前端一致的客户端标识头（x-client-* 可帮助平台正确识别请求来源）
+        'x-client-bundle-id': 'com.deepseek.chat',
+        'x-client-locale': 'zh_CN',
+        'x-client-platform': 'web',
+        'x-client-version': '1.0.0',
+        'x-client-timezone-offset': String(-new Date().getTimezoneOffset() * 60),
+      }
+    }
+
+    // 创建 DeepSeek 平台充值订单（不产生任何扣款，只有扫码支付后才入账；二维码 15 分钟有效）
+    async function createTopUpOrder(amount) {
+      const amt = Number(amount)
+      if (!isFinite(amt) || amt < TOPUP_MIN_CNY || amt > TOPUP_MAX_CNY) {
+        return { ok: false, code: 'BAD_AMOUNT', error: '金额需在 ¥' + TOPUP_MIN_CNY + ' – ¥' + TOPUP_MAX_CNY + ' 之间' }
+      }
+      let cred
+      try {
+        cred = await ctx.credentials.resolve('DEEPSEEK_PLATFORM_TOKEN')
+      } catch (err) {
+        return { ok: false, code: 'NO_TOKEN', error: '平台令牌读取失败: ' + String((err && err.message) || err).slice(0, 120) }
+      }
+      if (!cred) {
+        return { ok: false, code: 'NO_TOKEN', error: '未配置 DEEPSEEK_PLATFORM_TOKEN，投喂需要平台会话令牌（获取方式见 README「投喂」章节）' }
+      }
+      const token = String(cred.value).replace(/^Bearer\s+/i, '')
+      let res
+      try {
+        res = await fetch(PLATFORM_API + '/api/v1/payments', {
+          method: 'POST',
+          headers: platformHeaders(token),
+          body: JSON.stringify({
+            order_info: {
+              payment_method_type: 'CMB_UNIONPAY',
+              fallback_method_type: 'ALIPAY',
+              amount: String(amt),
+              currency: 'CNY',
+              request_id: randomUUID(),
+            },
+          }),
+          signal: AbortSignal.timeout(20000),
+        })
+      } catch (err) {
+        return { ok: false, code: 'NET', transient: true, error: '请求平台失败: ' + String((err && err.message) || err).slice(0, 150) }
+      }
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403) {
+          return tokenExpiredResult()
+        }
+        return { ok: false, code: 'HTTP', error: '平台接口 HTTP ' + res.status }
+      }
+      let data
+      try {
+        data = await res.json()
+      } catch (err) {
+        return { ok: false, code: 'PARSE', error: '平台接口返回异常' }
+      }
+      const biz = data && data.data && data.data.biz_data
+      if (!biz || !biz.payment_order_id || !biz.url) {
+        const code = (data && data.data && data.data.biz_code) ?? -1
+        const msg = (data && data.data && data.data.biz_msg) || (data && data.msg) || ''
+        if (isAuthFailureMsg(msg)) {
+          return tokenExpiredResult()
+        }
+        if (code === 1 || code === 2) {
+          return { ok: false, code: 'BAD_AMOUNT', error: '金额不合法（平台拒绝）' }
+        }
+        return { ok: false, code: 'BIZ', error: '平台返回异常: ' + String(msg || code).slice(0, 150) }
+      }
+      return { ok: true, paymentOrderId: biz.payment_order_id, qrUrl: biz.url, amount: String(biz.amount || amt) }
+    }
+
+    // 轮询订单支付状态；支付成功后清空余额缓存，让下一次余额请求立即拉取新余额
+    async function pollTopUpOrder(orderId) {
+      let cred
+      try {
+        cred = await ctx.credentials.resolve('DEEPSEEK_PLATFORM_TOKEN')
+      } catch (err) {
+        return { ok: false, code: 'NO_TOKEN', error: '平台令牌读取失败' }
+      }
+      if (!cred) return { ok: false, code: 'NO_TOKEN', error: '未配置 DEEPSEEK_PLATFORM_TOKEN' }
+      const token = String(cred.value).replace(/^Bearer\s+/i, '')
+      let res
+      try {
+        res = await fetch(PLATFORM_API + '/api/v1/payments/' + encodeURIComponent(orderId) + '/capture', {
+          method: 'POST',
+          headers: platformHeaders(token),
+          body: '',
+          signal: AbortSignal.timeout(15000),
+        })
+      } catch (err) {
+        return { ok: false, code: 'NET', transient: true, error: String((err && err.message) || err).slice(0, 120) }
+      }
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403) return tokenExpiredResult()
+        return { ok: false, code: 'HTTP', error: '平台接口 HTTP ' + res.status }
+      }
+      let data
+      try {
+        data = await res.json()
+      } catch (err) {
+        return { ok: false, code: 'PARSE', error: '平台接口返回异常' }
+      }
+      const order = data && data.data && data.data.biz_data && data.data.biz_data.order
+      if (!order || !order.status) return { ok: false, code: 'SHAPE', error: '轮询返回结构异常' }
+      if (order.status === 'SUCCESS') balanceCache = null
+      return { ok: true, status: String(order.status), paidAt: order.paid_at || null, walletUpdated: !!order.wallet_updated }
+    }
+
+    let alertCache = null
+    function isAuthFailureMsg(msg) {
+      return /authorization failed|invalid token|unauthorized|authentication failed/i.test(String(msg || ''))
+    }
+    // 令牌失效：清掉预警缓存（让按钮状态在下一次请求时更新），返回统一的干净提示。
+    // 不做会话锁存——令牌修好后下一次请求即可恢复正常。
+    function tokenExpiredResult() {
+      alertCache = null
+      return { ok: false, code: 'TOKEN_EXPIRED', error: '令牌过期，请重新获取' }
+    }
+    // 读取平台余额预警设置（users/current 的 balance_alert），按账户 currency 取对应币种
+    async function fetchAlertConfig() {
+      const now = Date.now()
+      if (alertCache && now - alertCache.at < 60000) return alertCache.payload
+      let cred
+      try {
+        cred = await ctx.credentials.resolve('DEEPSEEK_PLATFORM_TOKEN')
+      } catch (err) {
+        return { ok: false, code: 'NO_TOKEN', error: '平台令牌读取失败' }
+      }
+      if (!cred) return { ok: false, code: 'NO_TOKEN', error: '未配置 DEEPSEEK_PLATFORM_TOKEN' }
+      const token = String(cred.value).replace(/^Bearer\s+/i, '')
+      let res
+      try {
+        res = await fetch(PLATFORM_API + '/auth-api/v0/users/current', {
+          headers: platformHeaders(token),
+          signal: AbortSignal.timeout(15000),
+        })
+      } catch (err) {
+        return { ok: false, code: 'NET', transient: true, error: String((err && err.message) || err).slice(0, 120) }
+      }
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403) return tokenExpiredResult()
+        return { ok: false, code: 'HTTP', error: '平台接口 HTTP ' + res.status }
+      }
+      let data
+      try {
+        data = await res.json()
+      } catch (err) {
+        return { ok: false, code: 'PARSE', error: '平台接口返回异常' }
+      }
+      const bizData = data && data.data && data.data.biz_data
+      if (!bizData || typeof bizData.currency !== 'string') {
+        return { ok: false, code: 'SHAPE', error: 'users/current 返回结构异常' }
+      }
+      const ba = bizData.balance_alert
+      const currency = bizData.currency.toUpperCase()
+      // 按账户币种取 balance_alert[currency]；若该币种无条目则回退到任意一个可用币种
+      let alert = ba && ba[currency]
+      if (!alert) {
+        const keys = Object.keys(ba || {})
+        const first = keys.find((k) => ba[k] && typeof ba[k].enabled === 'boolean' && 'alert_bound' in ba[k])
+        alert = first ? ba[first] : null
+      }
+      if (!alert || typeof alert.enabled !== 'boolean' || !('alert_bound' in alert)) {
+        return { ok: false, code: 'SHAPE', error: 'users/current 返回结构异常' }
+      }
+      const bound = Number(alert.alert_bound)
+      const payload = {
+        ok: true,
+        enabled: !!alert.enabled,
+        alertBound: isFinite(bound) ? bound : null,
+      }
+      alertCache = { at: now, payload }
+      return payload
+    }
+
     function computeTodayUsage(data) {
       // data.data.biz_data.series[]: [{model, buckets:[{time, usage:{RESPONSE_TOKEN, PROMPT_CACHE_HIT_TOKEN, PROMPT_CACHE_MISS_TOKEN}}]}]
       let d = data
@@ -1640,6 +2172,7 @@ function apply(ctx) {
               bubbleOn: parsed.bubbleOn !== false,
               turnCostOn: parsed.turnCostOn !== false,
               turnCostCloseMs: typeof parsed.turnCostCloseMs === 'number' ? parsed.turnCostCloseMs : 5000,
+              topupAmount: typeof parsed.topupAmount === 'number' && isFinite(parsed.topupAmount) ? Math.min(100000, Math.max(1, Math.round(parsed.topupAmount))) : 10,
             }
           }
         } catch (err) {}
@@ -1647,13 +2180,14 @@ function apply(ctx) {
       return null
     }
 
-    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs) {
+    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs, topupAmount) {
       const um = normalizeUsageMode(usageMode)
       const pm = peakMode === 'liangwen' || peakMode === 'qiangqiang' ? peakMode : 'default'
       const bo = bubbleOn !== false
       const tco = turnCostOn !== false
       // 0 是合法值（不自动关闭），只有缺失/非法时才回落默认 5 秒
       const tcc = typeof turnCostCloseMs === 'number' && turnCostCloseMs >= 0 ? turnCostCloseMs : 5000
+      const ta = typeof topupAmount === 'number' && isFinite(topupAmount) ? Math.min(100000, Math.max(1, Math.round(topupAmount))) : 10
       const body = JSON.stringify({
         scale: scale,
         sound: sound !== false,
@@ -1664,6 +2198,7 @@ function apply(ctx) {
         bubbleOn: bo,
         turnCostOn: tco,
         turnCostCloseMs: tcc,
+        topupAmount: ta,
         updatedAt: new Date().toISOString(),
       })
       for (const p of SIZE_FILE_CANDIDATES) {
@@ -1680,6 +2215,7 @@ function apply(ctx) {
             bubbleOn: bo,
             turnCostOn: tco,
             turnCostCloseMs: tcc,
+            topupAmount: ta,
           }
         } catch (err) {}
       }
@@ -1759,6 +2295,72 @@ function apply(ctx) {
 
     disposers.push(ctx.webServer.register({
       kind: 'exact',
+      path: '/dsh-whale/topup.json',
+      handler: async (req, res) => {
+        if (req.method !== 'POST') {
+          res.writeHead(405, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: false, code: 'METHOD', error: 'method not allowed' }))
+          return
+        }
+        try {
+          const body = await readBody(req)
+          let amount = null
+          try { amount = Number(JSON.parse(body).amount) } catch (err) {}
+          const payload = await createTopUpOrder(amount)
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify(payload))
+        } catch (err) {
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: false, code: 'ERROR', error: String((err && err.message) || err).slice(0, 200) }))
+        }
+      },
+    }))
+
+    disposers.push(ctx.webServer.register({
+      kind: 'exact',
+      path: '/dsh-whale/topup-poll.json',
+      handler: async (req, res) => {
+        if (req.method !== 'POST') {
+          res.writeHead(405, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: false, code: 'METHOD', error: 'method not allowed' }))
+          return
+        }
+        try {
+          const body = await readBody(req)
+          let orderId = ''
+          try { orderId = String(JSON.parse(body).orderId || '') } catch (err) {}
+          if (!orderId) {
+            res.writeHead(200, JSON_HEADERS)
+            res.end(JSON.stringify({ ok: false, code: 'BAD_ORDER', error: 'missing orderId' }))
+            return
+          }
+          const payload = await pollTopUpOrder(orderId)
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify(payload))
+        } catch (err) {
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: false, code: 'ERROR', error: String((err && err.message) || err).slice(0, 200) }))
+        }
+      },
+    }))
+
+    disposers.push(ctx.webServer.register({
+      kind: 'exact',
+      path: '/dsh-whale/alert.json',
+      handler: async (req, res) => {
+        try {
+          const payload = await fetchAlertConfig()
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify(payload))
+        } catch (err) {
+          res.writeHead(200, JSON_HEADERS)
+          res.end(JSON.stringify({ ok: false, code: 'ERROR', error: String((err && err.message) || err).slice(0, 200) }))
+        }
+      },
+    }))
+
+    disposers.push(ctx.webServer.register({
+      kind: 'exact',
       path: '/dsh-whale/last-turn.json',
       handler: (req, res) => {
         // 返回最近一轮已完成的对话消耗；seq 递增供前端判断「新的一轮」
@@ -1791,7 +2393,7 @@ function apply(ctx) {
                 balanceCache = null
               }
             }
-            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs)
+            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs, parsed.topupAmount)
             res.writeHead(result.ok ? 200 : 500, JSON_HEADERS)
             res.end(JSON.stringify(result))
           } catch (err) {
@@ -1850,6 +2452,26 @@ function apply(ctx) {
 
     disposers.push(ctx.webServer.register({
       kind: 'exact',
+      path: '/dsh-whale/qrlib.js',
+      handler: (req, res) => {
+        let bytes = null
+        try { bytes = fs.readFileSync(QRLIB_FILE) } catch (err) {}
+        if (!bytes || bytes.length === 0) {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+          res.end('qrcode-generator source unavailable')
+          return
+        }
+        res.writeHead(200, {
+          'Content-Type': 'application/javascript; charset=utf-8',
+          'Cache-Control': 'no-store',
+          'Content-Length': String(bytes.length),
+        })
+        res.end(bytes)
+      },
+    }))
+
+    disposers.push(ctx.webServer.register({
+      kind: 'exact',
       path: '/dsh-whale/widget.js',
       handler: (req, res) => {
         res.writeHead(200, {
@@ -1861,6 +2483,11 @@ function apply(ctx) {
     }))
 
     disposers.push(ctx.webServer.tapIndex((html) => {
+      // qrlib 必须先于 widget 加载（defer 按文档顺序执行）
+      if (html.indexOf('/dsh-whale/qrlib.js') === -1) {
+        const tag = '<script defer src="/dsh-whale/qrlib.js"></script>'
+        html = html.indexOf('</body>') !== -1 ? html.replace('</body>', tag + '</body>') : html + tag
+      }
       if (html.indexOf('/dsh-whale/widget.js') !== -1) return html
       const tag = '<script defer src="/dsh-whale/widget.js"></script>'
       if (html.indexOf('</body>') !== -1) return html.replace('</body>', tag + '</body>')

--- a/lib/qrcode-generator.js
+++ b/lib/qrcode-generator.js
@@ -1,0 +1,2297 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));


### PR DESCRIPTION
新增「投喂」功能：
- 在配置DEEPSEEK_PLATFORM_TOKEN后，可生成微信/支付宝均可扫码支付的 DeepSeek 余额充值二维码
- 直接调用官网同一套充值接口，不是“中转充值”
- 余额低于预警阈值时自动提示，阈值来自平台的用户设置

改动 3 个文件
- lib/index.js：「投喂」功能 + 代码合并
- lib/qrcode-generator.js：内嵌 MIT 许可的二维码编码库（qrcode-generator 2.0.4原样源码，非新逻辑）
- README：「投喂」功能的简要说明