### PR TITLE
fix: 拖拽保存的位置刷新后丢失，挂件回到角落（#43）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -856,7 +856,11 @@ function saveConfig() {
       hAnchor: hAnchor,
       hDist: hDist,
       vAnchor: topDist <= bottomDist ? 'top' : 'bottom',
-      vDist: Math.round(Math.min(topDist, bottomDist))
+      vDist: Math.round(Math.min(topDist, bottomDist)),
+      // 附带本机几何相关配置缓存：加载时同步还原，保证首帧坐标精确（无需等服务端）
+      scale: state.scale,
+      gapOn: scrollGapOn,
+      gapPx: Math.round(scrollGapPx)
     }))
   } catch (err) {}
 }
@@ -909,6 +913,12 @@ function setScrollGapPx(v) {
 }
 function scaleToDisplay(s) {
   return Math.round((s - MIN_SCALE) / ((MAX_SCALE - MIN_SCALE) / 19)) + 1
+}
+function applyScaleUI(s) {
+  state.scale = s
+  root.style.setProperty('--dshw-scale', String(s))
+  scaleInput.value = String(s)
+  scaleNumber.value = String(scaleToDisplay(s))
 }
 function setScale(v) {
   var next = Math.round(Math.min(MAX_SCALE, Math.max(MIN_SCALE, Number(v))) * 10) / 10
@@ -1293,9 +1303,60 @@ window.addEventListener('resize', function () {
   settle()
 })
 
-var rect0 = root.getBoundingClientRect()
-state.left = rect0.left
-state.top = rect0.top
+// 相对边框恢复（localStorage 锚点，仅认 v:2 净距离格式；旧格式废弃保持默认右下角吸附）。
+// 只做几何还原：按当前缩放/避让状态计算坐标、还原吸附态并把净距离交给 hOff/vOff
+// （settle 锚定分支按偏移量重算坐标，置 0 会把位置打回角落 #43）。
+// 启动时同步调用一次保证首帧即在保存位；服务端配置到达后再调用一次纠正近似值。
+function restoreSavedPos() {
+  try {
+    var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
+    if (!a || a.v !== 2 || (a.hAnchor !== 'left' && a.hAnchor !== 'right') || typeof a.hDist !== 'number' ||
+        (a.vAnchor !== 'top' && a.vAnchor !== 'bottom') || typeof a.vDist !== 'number') return false
+    var vpA = viewport()
+    var wA = root.offsetWidth || root.getBoundingClientRect().width || 0
+    var hA = root.offsetHeight || root.getBoundingClientRect().height || 0
+    // 锚点存的是净距离：右锚点按当前避让开关叠加避让距离
+    var effectiveRightDist = a.hAnchor === 'right' ? a.hDist + (scrollGapOn ? rightGap() : 0) : a.hDist
+    var lA = a.hAnchor === 'left' ? a.hDist : vpA.w - effectiveRightDist - wA
+    var tA = a.vAnchor === 'top' ? a.vDist : vpA.h - a.vDist - hA
+    state.left = clamp(lA, 0, Math.max(0, vpA.w - wA))
+    state.top = clamp(tA, 0, Math.max(0, vpA.h - hA))
+    state.h = a.hAnchor
+    state.hOff = a.hDist
+    state.v = a.vAnchor
+    state.vOff = a.vDist
+    settle()
+    return true
+  } catch (err) { return false }
+}
+// 应用随锚点缓存的几何配置（缩放/避让）。仅启动时使用：
+// 服务端 size.json 才是权威配置源，fetch 后以服务端为准，避免陈旧缓存反向覆盖。
+function applyCachedGeoCfg() {
+  try {
+    var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
+    if (!a) return
+    if (typeof a.gapOn === 'boolean') {
+      scrollGapOn = a.gapOn
+      scrollGapToggle.checked = a.gapOn
+      scrollGapInput.disabled = !a.gapOn
+    }
+    if (typeof a.gapPx === 'number') {
+      scrollGapPx = a.gapPx > 0 ? Math.round(a.gapPx) : 0
+      scrollGapInput.value = String(scrollGapPx)
+    }
+    if (typeof a.scale === 'number' && a.scale >= MIN_SCALE - 0.1 && a.scale <= MAX_SCALE + 0.1) {
+      applyScaleUI(a.scale)
+    }
+  } catch (err) {}
+}
+
+// 启动即同步还原上次保存的位置，避免首帧闪现默认角落再跳到保存位（#43）
+applyCachedGeoCfg()
+if (!restoreSavedPos()) {
+  var rect0 = root.getBoundingClientRect()
+  state.left = rect0.left
+  state.top = rect0.top
+}
 express()
 render()
 applySoundSet()
@@ -1304,10 +1365,7 @@ fetch(SIZE_URL, { cache: 'no-store' })
   .then(function (r) { return r.json() })
   .then(function (d) {
     if (d && typeof d.scale === 'number' && d.scale >= MIN_SCALE - 0.1 && d.scale <= MAX_SCALE + 0.1) {
-      state.scale = d.scale
-      root.style.setProperty('--dshw-scale', String(d.scale))
-      scaleInput.value = String(d.scale)
-      scaleNumber.value = String(scaleToDisplay(d.scale))
+      applyScaleUI(d.scale)
       settle()
     }
     if (d && typeof d.vol === 'number') {
@@ -1355,32 +1413,8 @@ fetch(SIZE_URL, { cache: 'no-store' })
       scrollGapPx = d.scrollGapPx > 0 ? Math.round(d.scrollGapPx) : 0
       scrollGapInput.value = String(scrollGapPx)
     }
-    // 相对边框恢复（localStorage 锚点）：窗口变化后保持离边距离。
-    // 仅认 v:2 净距离格式；旧格式（含避让距离）废弃，挂件保持默认右下角吸附。
-    // 恢复时还原吸附状态（hAnchor/vAnchor → state.h/v），避免挂件变自由位置
-    // 导致避让调节不实时（settle 自由分支只 clamp 不重算位置）。
-    try {
-      var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
-      if (a && a.v === 2 && (a.hAnchor === 'left' || a.hAnchor === 'right') && typeof a.hDist === 'number' &&
-          (a.vAnchor === 'top' || a.vAnchor === 'bottom') && typeof a.vDist === 'number') {
-        var vpA = viewport()
-        var wA = root.offsetWidth || root.getBoundingClientRect().width || 0
-        var hA = root.offsetHeight || root.getBoundingClientRect().height || 0
-        // 锚点存的是净距离：右锚点按当前避让开关叠加避让距离
-        var effectiveRightDist = a.hAnchor === 'right' ? a.hDist + (scrollGapOn ? rightGap() : 0) : a.hDist
-        var lA = a.hAnchor === 'left' ? a.hDist : vpA.w - effectiveRightDist - wA
-        var tA = a.vAnchor === 'top' ? a.vDist : vpA.h - a.vDist - hA
-        state.left = clamp(lA, 0, Math.max(0, vpA.w - wA))
-        state.top = clamp(tA, 0, Math.max(0, vpA.h - hA))
-        // 按锚点还原吸附状态（贴边锚点 → 吸附；自由位锚点 → 自由）
-        // hOff/vOff 必须还原为保存的净距离：settle() 对锚定分支按偏移量重算坐标，置 0 会把位置打回角落（#43）
-        state.h = a.hAnchor
-        state.hOff = a.hDist
-        state.v = a.vAnchor
-        state.vOff = a.vDist
-        settle()
-      }
-    } catch (err) {}
+    // 相对边框恢复：启动时已同步还原过首帧位置，这里按服务端权威配置（避让/缩放）再纠正一次
+    restoreSavedPos()
     refresh(false)
   })
   .catch(function () { refresh(false) })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1350,14 +1350,18 @@ function applyCachedGeoCfg() {
   } catch (err) {}
 }
 
-// 启动即同步还原上次保存的位置，避免首帧闪现默认角落再跳到保存位（#43）
+// 启动即同步还原上次保存的位置，避免首帧闪现默认角落再跳到保存位（#43）。
+// 还原期间的布局读取会锁定未翻转的基线样式，若不禁用过渡，
+// 随后补上的 dshwv-left 会触发 transform .3s 翻转动画，故同 setScale 先关后开。
 applyCachedGeoCfg()
+root.style.transition = 'none'
 if (!restoreSavedPos()) {
   var rect0 = root.getBoundingClientRect()
   state.left = rect0.left
   state.top = rect0.top
 }
 express()
+requestAnimationFrame(function () { root.style.transition = '' })
 render()
 applySoundSet()
 setupHitTest()

--- a/lib/index.js
+++ b/lib/index.js
@@ -1280,9 +1280,10 @@ function applyAnchorPos() {
     state.left = clamp(l, 0, Math.max(0, vp.w - w))
     state.top = clamp(t, 0, Math.max(0, vp.h - h))
     state.h = a.hAnchor
-    state.hOff = 0
+    // 同 #43：还原净距离，避免后续 settle() 按偏移量重算时丢失位置
+    state.hOff = a.hDist
     state.v = a.vAnchor
-    state.vOff = 0
+    state.vOff = a.vDist
     express()
     return true
   } catch (err) { return false }
@@ -1372,10 +1373,11 @@ fetch(SIZE_URL, { cache: 'no-store' })
         state.left = clamp(lA, 0, Math.max(0, vpA.w - wA))
         state.top = clamp(tA, 0, Math.max(0, vpA.h - hA))
         // 按锚点还原吸附状态（贴边锚点 → 吸附；自由位锚点 → 自由）
+        // hOff/vOff 必须还原为保存的净距离：settle() 对锚定分支按偏移量重算坐标，置 0 会把位置打回角落（#43）
         state.h = a.hAnchor
-        state.hOff = 0
+        state.hOff = a.hDist
         state.v = a.vAnchor
-        state.vOff = 0
+        state.vOff = a.vDist
         settle()
       }
     } catch (err) {}


### PR DESCRIPTION
## 问题

#43：拖拽结束 saveConfig() 已正确把锚点净距离写入 \localStorage(dshw-pos)\，但刷新页面后挂件仍回到右下角（或最近角落）。

## 根因

恢复路径先把 \hDist/vDist\ 换算成正确的像素坐标，但随即把偏移量置 0 再调位置重算：

- **加载恢复**（\etch(SIZE_URL).then\ 内）：\state.h = a.hAnchor; state.hOff = 0; ...; settle()\
- **resize 恢复**（\pplyAnchorPos()\）：同样置 0 后 \xpress()\

而 \settle()\ 对锚定状态不是取 \state.left/top\，而是按偏移量重算：

\\\js
if (state.h === 'right') state.left = Math.max(0, vp.w - w - state.hOff - rightGap())   // hOff=0 → 贴右
if (state.v === 'bottom') state.top = Math.max(0, vp.h - h - state.vOff)                // vOff=0 → 贴底
\\\

刚恢复的距离被 \hOff=0 / vOff=0\ 覆盖，挂件永远贴回角落。\pplyAnchorPos()\ 路径虽用 \xpress()\ 渲染暂时保留坐标，但 \hOff/vOff\ 残留为 0，后续任何 \settle()\ 触发同样丢位置。

## 改动

恢复时把保存的净距离直接还给 \hOff/vOff\（与保存时「净距离 = 总距离 − 避让」的约定一致，右锚点由 \settle()\ 内部再叠加 \ightGap()\）：

| 位置 | 原代码 | 修复后 |
|------|--------|--------|
| 加载恢复 | \state.hOff = 0; state.vOff = 0; settle()\ | \state.hOff = a.hDist; state.vOff = a.vDist; settle()\ |
| resize 恢复 | \state.hOff = 0; state.vOff = 0; express()\ | \state.hOff = a.hDist; state.vOff = a.vDist; express()\ |

共 2 处、4 行。不动版本号。

## 验证

在 Node 最小 DOM 桩环境中提取并真实执行内嵌挂件脚本（WIDGET_JS），模拟完整「拖拽松开 → F5」流程：

| 场景 | 结果 |
|------|------|
| S1 右下角拖到 (1300,600) 刷新 | ✅ 保持 (1300,600)（修复前回到 (1720,880)） |
| S2 避让滚动条开启往返（净距离 403 = 420−17） | ✅ 保持 (1300,600)，避让距离正确叠加回算 |
| S3 自由位拖拽（left/700 + bottom/430 锚点）刷新 | ✅ 保持 (700,450) |
| S4 缩窗保持离边距离 / 窗口复原回原位 | ✅ (700,270) → 复原 (700,450) |

Closes #43