### PR TITLE
ci: 发布时自动创建 GitHub Release 并生成 PR changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,9 @@ name: Publish to npm
 
 # 事件驱动发布：main 分支有新提交即自动发布（不再需要外部定时轮询）
 # 版本管理：不自动递增，发布版本号 = 当前 package.json 的 version 字段
-# 发版流程：手动修改 version → push → 本 workflow 自动发布
+# 发版流程：手动修改 version → push → 本 workflow 自动发布并创建同名 GitHub Release
+# Release changelog：上一版本 tag（v*）到当前之间合入 main 的 PR 标题与编号；
+#                    仓库尚无任何 tag 时回退为全部已合并 PR
 on:
   push:
     branches: [main]
@@ -14,14 +16,17 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 拉全量历史与 tag，changelog 需要 diff 上一个版本 tag
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -65,3 +70,55 @@ jobs:
         env:
           # 可选：若在仓库设置了 NPM_TOKEN secret 则用它；未设置时自动走 OIDC
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # 生成 changelog：上个 v* tag 之后合入 main 的 PR（标题 + 编号），无 tag 则取全部
+      - name: Build release changelog
+        id: changelog
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -n "$PREV_TAG" ]; then
+            # 用 Unix 时间戳比较：mergedAt 是 UTC(Z)，%cI 带本地时区偏移，字符串比较跨时区会错判
+            SINCE=$(git log -1 --format=%ct "$PREV_TAG")
+            echo "changelog 范围：${PREV_TAG} 之后"
+          else
+            SINCE="0"
+            echo "仓库没有 tag，changelog 回退为全部已合并 PR"
+          fi
+          gh pr list --state merged --base main --limit 500 --json number,title,mergedAt \
+            | jq -r --argjson since "${SINCE:-0}" \
+              '[ .[] | select($since == 0 or (.mergedAt | fromdateiso8601) > $since) ]
+               | sort_by(.number)
+               | .[] | "- \(.title) (#\(.number))"' > pr_lines.md
+          if [ ! -s pr_lines.md ]; then
+            echo "- 本次发布无关联的合并 PR" > pr_lines.md
+          fi
+          {
+            echo "## What's Changed"
+            echo
+            cat pr_lines.md
+            echo
+            if [ -n "$PREV_TAG" ]; then
+              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...v${VERSION}"
+            fi
+          } > release_notes.md
+          cat release_notes.md
+
+      # 创建 GitHub Release 与 v<version> tag；幂等：release 已存在则跳过
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} 已存在，跳过创建"
+            exit 0
+          fi
+          gh release create "v${VERSION}" \
+            --target "${{ github.sha }}" \
+            --title "v${VERSION}" \
+            --notes-file release_notes.md


### PR DESCRIPTION
## 功能

在现有 \Publish to npm\ workflow 上扩展：npm 发布成功（版本未发布过）后自动创建同名 GitHub Release（\<version>\），changelog 自动收录**上一版本 tag 到本次发布之间合入 main 的 PR 标题与编号**。

## 行为

- **触发条件**：与发布一致——main 有新 push 且该版本未在 npm 发布过；重复运行幂等（release 已存在则跳过）
- **changelog 格式**：
  \\\
  ## What's Changed
  - feat: xxx (#31)
  - fix: yyy (#33)
  **Full Changelog**: https://github.com/<repo>/compare/v0.2.8...v0.2.9
  \\\
- **范围判定**：\git describe --tags --abbrev=0\ 取上一个 \*\ tag，按 tag 提交时间戳过滤 PR 的 \mergedAt\；仓库尚无任何 tag 时回退为全部已合并 PR
- **权限**：\contents: read → write\（创建 release/tag 所需）；checkout 改为 \etch-depth: 0\ 拉取全量 tag

## 验证

用上游仓库真实数据本地模拟 changelog 脚本：

- 以 v0.2.8 对应提交时间为界 → 正确输出 #31、#33（当时唯一已合并的两个后续 PR）
- 无 tag 回退（since=0）→ 输出全部 9 个已合并 PR
- 时间比较采用 Unix 时间戳（\%ct\ + jq \romdateiso8601\）：GitHub 返回 UTC、git 本地时区偏移，字符串直接比较会跨时区错判