### PR TITLE
fix: 移动端操作异常——触屏可拖拽鱼本体、菜单按钮可点开（#47）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ var css = [
   '.dshwv-root.dshwv-left{transform:scaleX(-1)}',
   '.dshwv-root.dshwv-dragging{cursor:grabbing;transition:none}',
   '.dshwv-body{position:absolute;left:0;top:0;width:100%;height:100%;transform-origin:50% 100%;transition:transform .22s cubic-bezier(.34,1.56,.64,1)}',
-  '.dshwv-img{position:absolute;right:0;bottom:0;width:59.45%;height:59.45%;display:block;pointer-events:none;-webkit-user-drag:none;user-select:none}',
+  '.dshwv-img{position:absolute;right:0;bottom:0;width:59.45%;height:59.45%;display:block;pointer-events:auto;touch-action:none;-webkit-user-drag:none;user-select:none}',
   '.dshwv-bubble{position:absolute;left:0;top:0;width:100%;aspect-ratio:1026/700;pointer-events:none;z-index:1;--dshw-u:calc(var(--dshw-base) / 1026)}',
   '.dshwv-bubble svg{display:block;width:100%;height:100%;pointer-events:none}',
   '.dshwv-bubble svg path,.dshwv-bubble svg ellipse{pointer-events:none;cursor:pointer}',
@@ -1193,6 +1193,12 @@ function onDocClickStopper(e) {
   // 只在鲸鱼命中区域拦截 click（保持透明区 pass-through）。
   // 持久注册（不随 endDrag 移除）——click 在 pointerup 之后派发，
   // 若在 endDrag 移除会导致 click 穿透到下方元素（如误打开文件）。
+  // 放行挂件自身交互元素：菜单按钮画在鲸鱼图上、处于命中区内，
+  // 弱网下 hitReady=false 时 isWhaleHit 恒 true，会连按钮自己的 click 一起吞掉（#47）
+  try {
+    if (e.target && e.target.closest &&
+        (e.target.closest('.dshwv-menu-btn') || e.target.closest('.dshwv-menu') || e.target.closest('.dshwv-bubble'))) return
+  } catch (err) {}
   if (!isWhaleHit(e)) return
   try { e.preventDefault(); e.stopPropagation() } catch (err) {}
 }


### PR DESCRIPTION
## 问题（#47）

1. **手机上无法在鱼本体上交互**：拖动被浏览器手势抢占打断、滑动触发下拉刷新
2. **触屏点菜单按钮打不开菜单**：有聚焦但无反应

## 根因（复现定位）

### 问题一
挂件交互依赖 document 捕获拦截，但源码无任何 \	ouch-action\ 声明。移动端浏览器会把手势判定为滚动/下拉刷新并夺走指针（\pointercancel\），而 \ndDrag\ 用事件坐标重算位置——cancel 事件坐标常为 (0,0)，挂件直接瞬移到左上角，表现为「拖动失效」。

### 问题二
真正的触发器是 \isWhaleHit\ 的回退分支（lib/index.js L1139 附近）：\!hitCanvas || !hitReady\ 时**无条件返回 true**。弱网下 image.png 未加载完时，document 捕获阶段的 \onDocClickStopper\ 把整个鲸鱼命中区的 click 一律吞掉——包括菜单按钮自己的 click。

> 补充实测：实际皮肤 DSniang1.png 在菜单按钮区域仅约 **4% 不透明像素**，正常加载时像素检测恰好放行——这就是桌面端一直没坏的原因；但厚皮素材或 hitReady=false 场景必然复现。

## 改动（2 处）

| 位置 | 改动 |
|------|------|
| \.dshwv-img\ CSS | \pointer-events:none\ → \uto\ + 新增 \	ouch-action:none\：触屏点在鱼本体上才归挂件处理，手势不再被抢占/下拉刷新 |
| \onDocClickStopper\ | 开头放行 \.dshwv-menu-btn / .dshwv-menu / .dshwv-bubble\ 目标，不再误拦挂件自身交互元素的 click |

鲸鱼本体的 click 穿透拦截逻辑保持不变。

## 复现与验证

Node 最小 DOM 桩环境提取真实挂件脚本执行，模拟完整触屏事件流（pointerdown/move/up/cancel + click 捕获→目标派发）：

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 拖动中 pointercancel(0,0) | 🐛 瞬移到 (0,0) | ✅ 正常拖放落点 |
| hitReady=false 点菜单按钮 | 🐛 菜单打不开（click 被 preventDefault） | ✅ 打开 |
| 厚皮素材（按钮区不透明）点按钮 | 🐛 同样吞 click | ✅ 打开 |
| 默认皮肤（按钮区透明）点按钮 | ✅ 正常（回归保障） | ✅ 正常 |
| 鲸鱼本体 click 防穿透 | ✅ | ✅ 不受影响 |

Closes #47