### PR TITLE
feat: 移动端适配与瞬移 bug 修复

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,7 +174,9 @@ var css = [
   '.dshwv-sound:hover{background:rgba(32,49,112,.16)}',
   '.dshwv-check{width:16px;height:16px;accent-color:#203170;cursor:pointer;flex:0 0 auto}',
   '.dshwv-menu-sep{height:1px;background:rgba(32,49,112,.25);margin:6px 0}',
-  '.dshwv-volpct{width:44px;text-align:right;color:#203170;font-size:12px}'
+  '.dshwv-volpct{width:44px;text-align:right;color:#203170;font-size:12px}',
+  // 移动端（与 dsh-mobile-ui 同一断点 ≤820px）：默认隐藏设置按钮与设置面板
+  '@media (max-width: 820px){.dshwv-menu-btn,.dshwv-menu{display:none}}'
 ].join('\\n')
 
 var styleEl = document.createElement('style')
@@ -1063,7 +1065,13 @@ function snapCheck() {
   var centerX = left + w / 2
   var centerY = top + h / 2
   var moved = false
-  if (centerX < vp.w / 4) {
+  if (isMobile()) {
+    // 移动端：水平一律贴右侧（桌面端保留原版左右吸附）
+    state.h = 'right'
+    state.hOff = 0
+    left = vp.w - w - rightGap()
+    moved = true
+  } else if (centerX < vp.w / 4) {
     state.h = 'left'
     state.hOff = 0
     left = 0
@@ -1092,6 +1100,99 @@ function snapCheck() {
     settle()
   }
 }
+// —— 移动端适配（与 dsh-mobile-ui 同一断点 ≤820px）——
+// 移动端：设置按钮默认隐藏（CSS）；触屏拖动不触发页面滚动（pointerdown 时临时给
+// 目标元素 touch-action:none，touchmove 再兜底 preventDefault）；位置策略：
+// 首页=右下角，进入会话（存在 [data-chat-flow]）=右上角；桌面端保持原版行为。
+var MOBILE_QUERY = '(max-width: 820px)'
+var mobileMq = null
+try { mobileMq = window.matchMedia(MOBILE_QUERY) } catch (err) {}
+var touchActionEl = null
+var touchDraggingWhale = false
+function isMobile() {
+  if (mobileMq) { try { return !!mobileMq.matches } catch (err) {} }
+  return (window.innerWidth || 1280) <= 820
+}
+function inConversation() {
+  try { return !!document.querySelector('[data-chat-flow]') } catch (err) { return false }
+}
+function panelTarget() {
+  if (!isMobile()) return null
+  return inConversation() ? { h: 'right', v: 'top' } : { h: 'right', v: 'bottom' }
+}
+var panelKey = null
+// 移动端固定尺寸为菜单档位 5（scale 1.0）：窄屏下更大档位显示不美观。
+// 只作用于显示，不写回 saveConfig —— 桌面端用户自定的尺寸保持不动。
+function applyMobileScale() {
+  if (!isMobile()) return
+  var target = Math.round((MIN_SCALE + (5 - 1) * (MAX_SCALE - MIN_SCALE) / 19) * 10) / 10
+  if (Math.abs(state.scale - target) < 0.001) return
+  var prevTrans = root.style.transition
+  root.style.transition = 'none'
+  var rect = root.getBoundingClientRect()
+  var fx = state.h === 'left' ? rect.left : rect.right
+  var fy = rect.bottom
+  state.scale = target
+  root.style.setProperty('--dshw-scale', String(target))
+  scaleInput.value = String(target)
+  scaleNumber.value = String(scaleToDisplay(target))
+  var r2 = root.getBoundingClientRect()
+  var vp = viewport()
+  if (state.h === 'left') {
+    state.left = Math.min(Math.max(fx, 0), Math.max(0, vp.w - r2.width))
+  } else {
+    state.left = Math.min(Math.max(fx - r2.width, 0), Math.max(0, vp.w - r2.width))
+  }
+  state.top = Math.min(Math.max(fy - r2.height, 0), Math.max(0, vp.h - r2.height))
+  express()
+  requestAnimationFrame(function () { root.style.transition = prevTrans })
+}
+function applyPanel(force) {
+  try {
+    var t = panelTarget()
+    var key = t ? t.h + '|' + t.v : 'desktop'
+    if (force || key !== panelKey) {
+      panelKey = key
+      if (t) {
+        state.h = t.h
+        state.hOff = 0
+        state.v = t.v
+        state.vOff = 0
+        settle()
+      }
+    }
+    applyMobileScale()
+  } catch (err) {}
+}
+function onPanelMqChange() { applyPanel(true) }
+try {
+  if (mobileMq && mobileMq.addEventListener) mobileMq.addEventListener('change', onPanelMqChange)
+} catch (err) {}
+try {
+  // 监听会话视图挂载/卸载（[data-chat-flow] 是 dsh-client-ui-conversation 设置的标记）
+  // 同一个 observer 顺带校正位置策略与弹窗隐藏。
+  new MutationObserver(function () { applyPanel(false) }).observe(document.body, { childList: true, subtree: true })
+} catch (err) {}
+function onDocTouchStart(e) {
+  try {
+    var t = e.changedTouches && e.changedTouches[0]
+    if (!t || typeof t.clientX !== 'number') { touchDraggingWhale = false; return }
+    if (e.target && e.target.closest && (e.target.closest('.dshwv-bubble') || e.target.closest('.dshwv-menu') || e.target.closest('.dshwv-menu-btn'))) {
+      touchDraggingWhale = false
+      return
+    }
+    touchDraggingWhale = isWhaleHit({ clientX: t.clientX, clientY: t.clientY })
+  } catch (err) { touchDraggingWhale = false }
+}
+function onDocTouchMove(e) {
+  try { if (touchDraggingWhale) e.preventDefault() } catch (err) {}
+}
+function onDocTouchEnd() { touchDraggingWhale = false }
+document.addEventListener('touchstart', onDocTouchStart, { passive: true })
+document.addEventListener('touchmove', onDocTouchMove, { passive: false })
+document.addEventListener('touchend', onDocTouchEnd, { passive: true })
+document.addEventListener('touchcancel', onDocTouchEnd, { passive: true })
+
 function positionMenu() {
   try {
     var r = root.getBoundingClientRect()
@@ -1161,6 +1262,13 @@ function onDocPointerDown(e) {
   if (e.button !== 0 && e.pointerType === 'mouse') return
   if (!isWhaleHit(e)) return
   try { e.preventDefault(); e.stopPropagation() } catch (err) {}
+  // 触屏拖动优化：触摸起点在鲸鱼上时，临时给目标元素设置 touch-action:none ——
+  // 浏览器在触摸手势开始时据此不放行滚动，否则手指一动就滚动并触发 pointercancel，
+  // 鲸鱼会瞬移/无法拖动。手势结束由 endDrag 恢复该属性。
+  if (e.pointerType === 'touch' && e.target && e.target.style) {
+    touchActionEl = e.target
+    try { touchActionEl.style.touchAction = 'none' } catch (err) {}
+  }
   var vp = viewport()
   var rect = root.getBoundingClientRect()
   drag = { active: true, startX: e.clientX, startY: e.clientY, origLeft: rect.left, origTop: rect.top, w: rect.width, h: rect.height, moved: false, vp: vp }
@@ -1229,15 +1337,32 @@ function endDrag(e, clickAllowed) {
   document.removeEventListener('pointercancel', onDocPointerCancel, true)
   pressUp()
   root.classList.remove('dshwv-dragging')
+  if (touchActionEl) {
+    try { touchActionEl.style.touchAction = '' } catch (err) {}
+    touchActionEl = null
+  }
   setWidgetCursor(isWhaleHit(e) ? 'grab' : '')
   if (clickAllowed && !drag.moved) { showBubble(); refresh(true); return }
+  // pointercancel（浏览器抢走手势：触摸滚动/系统手势等）引起的结束：取消事件的
+  // 坐标常为 0,0，绝不能拿来吸附（否则鲸鱼瞬移到左上角）。恢复拖动前位置即可——
+  // 这同时彻底修掉「touch 一下鲸鱼就飞到最左边挡住新建会话按钮」的 bug。
+  if (!clickAllowed) {
+    state.left = drag.origLeft
+    state.top = drag.origTop
+    settle()
+    return
+  }
   var dx = e.clientX - drag.startX
   var dy = e.clientY - drag.startY
   var left = clamp(drag.origLeft + dx, 0, Math.max(0, drag.vp.w - drag.w))
   var top = clamp(drag.origTop + dy, 0, Math.max(0, drag.vp.h - drag.h))
   var centerX = left + drag.w / 2
   var centerY = top + drag.h / 2
-  if (centerX < drag.vp.w / 4) {
+  if (isMobile()) {
+    // 移动端：水平一律贴右侧，不存在向左吸附（桌面端保留原版左右吸附）
+    state.h = 'right'
+    state.hOff = 0
+  } else if (centerX < drag.vp.w / 4) {
     state.h = 'left'
     state.hOff = 0
   } else if (centerX > drag.vp.w * 3 / 4) {
@@ -1288,6 +1413,7 @@ function applyAnchorPos() {
   } catch (err) { return false }
 }
 window.addEventListener('resize', function () {
+  applyPanel(false)
   if (state.h === null && state.v === null && applyAnchorPos()) return
   settle()
 })
@@ -1299,6 +1425,9 @@ express()
 render()
 applySoundSet()
 setupHitTest()
+// 移动端位置策略：首页=右下角 / 会话中=右上角（桌面端不变）。
+// 立即执行一次，随后 SIZE 配置与 DOM 变化（MutationObserver）会再次校正。
+applyPanel(true)
 fetch(SIZE_URL, { cache: 'no-store' })
   .then(function (r) { return r.json() })
   .then(function (d) {
@@ -1358,7 +1487,8 @@ fetch(SIZE_URL, { cache: 'no-store' })
     // 仅认 v:2 净距离格式；旧格式（含避让距离）废弃，挂件保持默认右下角吸附。
     // 恢复时还原吸附状态（hAnchor/vAnchor → state.h/v），避免挂件变自由位置
     // 导致避让调节不实时（settle 自由分支只 clamp 不重算位置）。
-    try {
+    // 移动端忽略 localStorage 恢复（位置由策略决定，避免先闪一下又跳走）。
+    if (!isMobile()) try {
       var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
       if (a && a.v === 2 && (a.hAnchor === 'left' || a.hAnchor === 'right') && typeof a.hDist === 'number' &&
           (a.vAnchor === 'top' || a.vAnchor === 'bottom') && typeof a.vDist === 'number') {
@@ -1380,8 +1510,9 @@ fetch(SIZE_URL, { cache: 'no-store' })
       }
     } catch (err) {}
     refresh(false)
+    applyPanel(false)
   })
-  .catch(function () { refresh(false) })
+  .catch(function () { refresh(false); applyPanel(false) })
 setInterval(function () { refresh(false) }, REFRESH_MS)
 
 // —— 每轮对话消耗检测：轮询 last-turn.json，出现新 seq 时弹消耗金额泡泡 ——


### PR DESCRIPTION
## 动机

移动端（窄屏）用户使用时会遇到两个问题：

1. **瞬移 bug（较严重）**：在手机上触摸鲸鱼，手指稍微一动浏览器会把手势识别为滚动并触发 `pointercancel`，该事件的 `clientX/clientY` 为 0。原实现按这个坐标做吸附，鲸鱼会**瞬移到窗口左上角**，正好挡住"新建会话"按钮；
2. **完全没有移动端适配**：无触屏拖动优化（拖动会被滚动打断）、窄屏下无位置策略、设置按钮在手机上缩小后难以点中且挡内容。

## 改动内容（全部只影响窄屏 ≤820px，桌面端行为不变）

- **位置策略**：首页显示在右下角；进入会话（页面出现 `[data-chat-flow]`，DSH 会话视图挂载标记）移动到右上角；会话退出回右下角。`matchMedia` + `MutationObserver` 实时跟随窗口缩放与会话切换。
- **瞬移修复**：`pointercancel` 等取消手势结束拖动时**恢复拖动前位置**，绝不按取消事件坐标吸附；同时移动端水平吸附一律贴右侧（不存在向左）。
- **触屏拖动优化**：触摸起点落在鲸鱼上时临时给目标元素 `touch-action:none`，并以 `touchmove` `preventDefault` 兜底，拖动不会触发页面滚动。
- **移动端默认隐藏设置按钮与设置面板**（点击鲸鱼仍可查看余额气泡）。
- **移动端固定尺寸为菜单档位 5**：窄屏下更大档位会溢出显示、不美观；桌面端用户自定义尺寸不受影响（不写回保存）。
- 移动端忽略 localStorage 位置记忆，避免加载时闪跳。

## 测试

无头 Chrome（500px 窄屏视口）回归：首页右下角 / 会话右上角 / 退出回右下角 / 移动端尺寸固定档位5 / 设置按钮隐藏 / 拖动后贴右侧 / pointercancel 恢复原位 / 轻点不瞬移，全部通过；桌面端（1280px）行为与原版一致。

## 说明

- 断点 `(max-width: 820px)` 与 DSH 移动端 UI 插件一致；
- 我日常自用了一段时间，改动是稳定版本。欢迎提意见，哪里不符合你的预期我可以改。

（另有一些自用向的小改动——设置面板样式、气泡开关交互、弹窗优先级——暂未包含在本 PR 中，如果感兴趣可以后续再聊。）
