### PR TITLE
fix: 修复挂件拖拽位置刷新后丢失（#55）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -840,7 +840,7 @@ function saveConfig() {
   try {
     fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs, scrollGapOn: scrollGapOn, scrollGapPx: scrollGapPx }) })
     // 锚点位置记忆：记录相对边框的离边距离，窗口 resize 后保持（localStorage）。
-    // v:2 = 净距离格式（剥离避让距离），v:1 旧格式含避让距离，恢复时废弃旧格式。
+    // v: 3 = 净距离格式+自由位标记（freeH/freeV 记录拖拽结束时各轴是否自由），旧格式 v:1/v:2 兼容读取，恢复时视为锚定并携带距离。
     var vp = viewport()
     var w = root.offsetWidth || root.getBoundingClientRect().width || 0
     var h = root.offsetHeight || root.getBoundingClientRect().height || 0
@@ -852,11 +852,13 @@ function saveConfig() {
     var hDistRaw = Math.round(Math.min(leftDist, rightDist))
     var hDist = hAnchor === 'right' && scrollGapOn ? Math.max(0, hDistRaw - rightGap()) : hDistRaw
     localStorage.setItem('dshw-pos', JSON.stringify({
-      v: 2,
+      v: 3,
       hAnchor: hAnchor,
       hDist: hDist,
       vAnchor: topDist <= bottomDist ? 'top' : 'bottom',
-      vDist: Math.round(Math.min(topDist, bottomDist))
+      vDist: Math.round(Math.min(topDist, bottomDist)),
+      freeH: state.h === null,
+      freeV: state.v === null
     }))
   } catch (err) {}
 }
@@ -1268,7 +1270,7 @@ function endDrag(e, clickAllowed) {
 function applyAnchorPos() {
   try {
     var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
-    if (!a || a.v !== 2 || (a.hAnchor !== 'left' && a.hAnchor !== 'right') || typeof a.hDist !== 'number' ||
+    if (!a || (a.v !== 2 && a.v !==3) || (a.hAnchor !== 'left' && a.hAnchor !== 'right') || typeof a.hDist !== 'number' ||
         (a.vAnchor !== 'top' && a.vAnchor !== 'bottom') || typeof a.vDist !== 'number') return false
     var vp = viewport()
     var w = root.offsetWidth || root.getBoundingClientRect().width || 0
@@ -1278,11 +1280,9 @@ function applyAnchorPos() {
     var l = a.hAnchor === 'left' ? a.hDist : vp.w - effectiveRightDist - w
     var t = a.vAnchor === 'top' ? a.vDist : vp.h - a.vDist - h
     state.left = clamp(l, 0, Math.max(0, vp.w - w))
-    state.top = clamp(t, 0, Math.max(0, vp.h - h))
-    state.h = a.hAnchor
-    state.hOff = 0
-    state.v = a.vAnchor
-    state.vOff = 0
+    state.top = clamp(t, 0, Math.max(0, vp.h - h))    
+    if (a.v === 3 && a.freeH) { state.h = null } else { state.h = a.hAnchor; state.hOff = a.hDist }
+    if (a.v === 3 && a.freeV) { state.v = null } else { state.v = a.vAnchor; state.vOff = a.vDist }
     express()
     return true
   } catch (err) { return false }
@@ -1355,12 +1355,10 @@ fetch(SIZE_URL, { cache: 'no-store' })
       scrollGapInput.value = String(scrollGapPx)
     }
     // 相对边框恢复（localStorage 锚点）：窗口变化后保持离边距离。
-    // 仅认 v:2 净距离格式；旧格式（含避让距离）废弃，挂件保持默认右下角吸附。
-    // 恢复时还原吸附状态（hAnchor/vAnchor → state.h/v），避免挂件变自由位置
-    // 导致避让调节不实时（settle 自由分支只 clamp 不重算位置）。
+    // v:2/v:3 均按「锚点 + 净距离」还原；v3 的 freeH/freeV 标记自由轴，自由轴保持 h/v=null（不强制贴边、不触发水平镜像），锚定轴携带离边距离。
     try {
       var a = JSON.parse(localStorage.getItem('dshw-pos') || 'null')
-      if (a && a.v === 2 && (a.hAnchor === 'left' || a.hAnchor === 'right') && typeof a.hDist === 'number' &&
+      if (a && (a.v === 2 || a.v === 3) && (a.hAnchor === 'left' || a.hAnchor === 'right') && typeof a.hDist === 'number' &&
           (a.vAnchor === 'top' || a.vAnchor === 'bottom') && typeof a.vDist === 'number') {
         var vpA = viewport()
         var wA = root.offsetWidth || root.getBoundingClientRect().width || 0
@@ -1369,13 +1367,21 @@ fetch(SIZE_URL, { cache: 'no-store' })
         var effectiveRightDist = a.hAnchor === 'right' ? a.hDist + (scrollGapOn ? rightGap() : 0) : a.hDist
         var lA = a.hAnchor === 'left' ? a.hDist : vpA.w - effectiveRightDist - wA
         var tA = a.vAnchor === 'top' ? a.vDist : vpA.h - a.vDist - hA
-        state.left = clamp(lA, 0, Math.max(0, vpA.w - wA))
-        state.top = clamp(tA, 0, Math.max(0, vpA.h - hA))
-        // 按锚点还原吸附状态（贴边锚点 → 吸附；自由位锚点 → 自由）
-        state.h = a.hAnchor
-        state.hOff = 0
-        state.v = a.vAnchor
-        state.vOff = 0
+        // v3：自由轴保持 h/v=null（不锚定、不镜像），锚定轴携带离边距离
+        if (a.v === 3 && a.freeH) {
+          state.h = null
+          state.left = clamp(lA, 0, Math.max(0, vpA.w - wA))
+        } else {
+          state.h = a.hAnchor
+          state.hOff = a.hDist
+        }
+        if (a.v === 3 && a.freeV) {
+          state.v = null
+          state.top = clamp(tA, 0, Math.max(0, vpA.h - hA))
+        } else {
+          state.v = a.vAnchor
+          state.vOff = a.vDist
+        }
         settle()
       }
     } catch (err) {}


### PR DESCRIPTION
## 修复内容
修复 #55：挂件拖拽到非贴角位置（留离边空隙或屏幕中间）后，刷新/重启位置跳回角落的问题。

## 根因
`saveConfig()` 把位置保存为「最近边 + 离边距离」(v:2)，但恢复逻辑算对 `left/top` 后把 `hOff/vOff` 硬置为 0，随后 `settle()` 按 0 距离重算 → 挂件被吸回角落。恢复时还把自由位置强制设为 `h='left'/'right'` 锚定，导致 `h='left'` 时触发水平镜像。

## 改动
- 恢复时保留离边距离：`state.hOff = a.hDist`、`state.vOff = a.vDist`（锚定轴）
- 存储格式升级 v:3：新增 `freeH`/`freeV` 标记自由位置，自由轴恢复为 `h/v=null`，不强制贴边、不触发镜像
- `applyAnchorPos()` 同步修复同款问题
- 旧 v:1/v:2 数据兼容读取

## 验证
A/B 对照（视口 1200×800，挂件 250×250，三场景）：
- 场景A 贴边留空隙：原逻辑跳回角落 ❌ → 修复后位置保留 ✅
- 场景B 中间偏左自由位：原逻辑跳角落+镜像 ❌ → 修复后位置保留+不镜像 ✅
- 场景C 左侧自由位：同 B ✅

浏览器实测：拖到中间 → F5 → 位置保留、不镜像 ✅

Fixes #55