### PR TITLE
feat: 每轮任务完成播放音效并发送 Windows 通知 (round-done sound + Windows toast)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
 
 // Package root: lib/index.js -> package root. Keeps the bundle relocatable
 // when installed as a normal DSH npm plugin (node_modules or a local link).
@@ -55,6 +56,12 @@ function soundSetFromUrl(url) {
     return m ? decodeURIComponent(m[1]) : ''
   } catch (err) { return '' }
 }
+// 自定义「任务完成音」：包内 assets/done.mp3 存在时，任务完成提醒优先播放它
+// （单音，独立于点击声）；文件缺失时路由 404，前端自动回退到当前音效组的两连音。
+const DONE_SOUND_CANDIDATES = [
+  path.join(PACKAGE_ROOT, 'assets', 'done.mp3'),
+  'D:/TestBox/deepseek/skin/done.mp3',
+]
 const BALANCE_URL = 'https://api.deepseek.com/user/balance'
 const BALANCE_TTL_MS = 25000
 const RUA_GIF_CANDIDATES = [
@@ -283,6 +290,19 @@ turnCostCloseInput.disabled = false // 跟随「每轮消耗提示」开关
 turnCostCloseInput.title = '填 0 表示不自动关闭，需手动点击关闭'
 turnCostCloseInput.addEventListener('input', function () { setTurnCostClose(turnCostCloseInput.value) })
 turnCostCloseInput.addEventListener('change', function () { setTurnCostClose(turnCostCloseInput.value) })
+// —— 任务完成提醒开关（音效 + Windows 系统通知）——
+var alertSoundToggle = document.createElement('input')
+alertSoundToggle.type = 'checkbox'
+alertSoundToggle.className = 'dshwv-check'
+alertSoundToggle.checked = true
+alertSoundToggle.title = '本轮任务完成时播放提示音效（跟随菜单音效与音量）'
+alertSoundToggle.addEventListener('change', function () { setAlertSoundOn(alertSoundToggle.checked) })
+var alertToastToggle = document.createElement('input')
+alertToastToggle.type = 'checkbox'
+alertToastToggle.className = 'dshwv-check'
+alertToastToggle.checked = true
+alertToastToggle.title = '本轮任务完成时发送 Windows 系统通知提醒'
+alertToastToggle.addEventListener('change', function () { setAlertToastOn(alertToastToggle.checked) })
 var scrollGapToggle = document.createElement('input')
 scrollGapToggle.type = 'checkbox'
 scrollGapToggle.className = 'dshwv-check'
@@ -338,6 +358,12 @@ row7.appendChild(turnCostToggle)
 row7.appendChild(menuLabel('自动关闭'))
 row7.appendChild(turnCostCloseInput)
 row7.appendChild(menuLabel('秒'))
+var row8 = menuRow()
+row8.appendChild(menuLabel('完成任务提醒'))
+row8.appendChild(alertSoundToggle)
+row8.appendChild(menuLabel('音效'))
+row8.appendChild(alertToastToggle)
+row8.appendChild(menuLabel('系统通知'))
 var row9 = menuRow()
 row9.appendChild(menuLabel('避让滚动条'))
 row9.appendChild(scrollGapToggle)
@@ -351,6 +377,7 @@ menuBox.appendChild(row4)
 menuBox.appendChild(row5)
 menuBox.appendChild(row6)
 menuBox.appendChild(row7)
+menuBox.appendChild(row8)
 menuBox.appendChild(menuSep1)
 menuBox.appendChild(row9)
 
@@ -833,12 +860,14 @@ var peakMode = 'default'
 var bubbleOn = true
 var turnCostOn = true
 var turnCostCloseMs = 5000
+var alertSoundOn = true
+var alertToastOn = true
 var costBubbleActive = false
 var scrollGapOn = false
 var scrollGapPx = 17
 function saveConfig() {
   try {
-    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs, scrollGapOn: scrollGapOn, scrollGapPx: scrollGapPx }) })
+    fetch(SIZE_URL, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ scale: state.scale, sound: soundOn, vol: soundVol, soundSet: soundSet, usageMode: usageMode, peakMode: peakMode, bubbleOn: bubbleOn, turnCostOn: turnCostOn, turnCostCloseMs: turnCostCloseMs, scrollGapOn: scrollGapOn, scrollGapPx: scrollGapPx, alertSoundOn: alertSoundOn, alertToastOn: alertToastOn }) })
     // 锚点位置记忆：记录相对边框的离边距离，窗口 resize 后保持（localStorage）。
     // v:2 = 净距离格式（剥离避让距离），v:1 旧格式含避让距离，恢复时废弃旧格式。
     var vp = viewport()
@@ -890,6 +919,16 @@ function setTurnCostClose(v) {
   var n = Math.max(0, Math.round(Number(v) || 0))
   turnCostCloseMs = n * 1000
   turnCostCloseInput.value = String(n)
+  saveConfig()
+}
+function setAlertSoundOn(v) {
+  alertSoundOn = !!v
+  alertSoundToggle.checked = alertSoundOn
+  saveConfig()
+}
+function setAlertToastOn(v) {
+  alertToastOn = !!v
+  alertToastToggle.checked = alertToastOn
   saveConfig()
 }
 function setScrollGapOn(v) {
@@ -1010,6 +1049,53 @@ function playRelease() {
     var p = releaseAudio.play()
     if (p && typeof p.catch === 'function') p.catch(function () {})
   } catch (err) {}
+}
+// —— 任务完成提示音 ——
+// 若自定义文件 /dsh-whale/sound/done.mp3 可用（包内 assets/done.mp3 或旧版
+// 绝对路径），优先单独播放它作为「完成音」；缺失/加载失败则回退为当前音效组
+// 的 press+release 两连音。临时新建 Audio，避免与进行中的点击按压音互相抢占。
+var doneMp3Ok = null // null=未探测 true=可用 false=不可用（不再重复尝试）
+function chimePair() {
+  if (!soundOn || !alertSoundOn) return
+  try {
+    var a = new Audio('/dsh-whale/sound/press.mp3?set=' + soundSet)
+    a.volume = soundVol
+    a.onended = function () {
+      try {
+        var b = new Audio('/dsh-whale/sound/release.mp3?set=' + soundSet)
+        b.volume = soundVol
+        var p2 = b.play()
+        if (p2 && typeof p2.catch === 'function') p2.catch(function () {})
+      } catch (err) {}
+    }
+    var p = a.play()
+    if (p && typeof p.catch === 'function') p.catch(function () {})
+  } catch (err) {}
+}
+function playDoneChime() {
+  if (!soundOn || !alertSoundOn) return
+  if (doneMp3Ok === false) { chimePair(); return }
+  try {
+    var fell = false
+    var fallback = function () {
+      if (fell) return
+      fell = true
+      doneMp3Ok = false
+      chimePair()
+    }
+    var a = new Audio('/dsh-whale/sound/done.mp3')
+    a.volume = soundVol
+    a.onerror = fallback
+    var p = a.play()
+    if (p && typeof p.catch === 'function') {
+      p.catch(fallback)
+    } else {
+      doneMp3Ok = true
+    }
+  } catch (err) {
+    doneMp3Ok = false
+    chimePair()
+  }
 }
 function pressDown() {
   body.style.transform = SQUISH
@@ -1345,6 +1431,14 @@ fetch(SIZE_URL, { cache: 'no-store' })
       turnCostCloseMs = d.turnCostCloseMs > 0 ? d.turnCostCloseMs : 0
       turnCostCloseInput.value = String(Math.round(turnCostCloseMs / 1000))
     }
+    if (d && typeof d.alertSoundOn === 'boolean') {
+      alertSoundOn = d.alertSoundOn
+      alertSoundToggle.checked = alertSoundOn
+    }
+    if (d && typeof d.alertToastOn === 'boolean') {
+      alertToastOn = d.alertToastOn
+      alertToastToggle.checked = alertToastOn
+    }
     if (d && typeof d.scrollGapOn === 'boolean') {
       scrollGapOn = d.scrollGapOn
       scrollGapToggle.checked = scrollGapOn
@@ -1402,6 +1496,8 @@ function pollLastTurn() {
         }
         if (d.seq > lastCostSeq) {
           lastCostSeq = d.seq
+          // 任务完成提醒：新的一轮已结束 → 播放完成音效（菜单「完成任务提醒-音效」开关控制）
+          if (alertSoundOn) playDoneChime()
           if (d.turn !== null && d.amount !== null) {
             showCostBubble(Number(d.amount))
           }
@@ -1429,11 +1525,82 @@ function apply(ctx) {
     let lastTurnSeq = 0
     const disposers = []
 
+    // —— Windows 任务完成通知（每轮会话 turn/end 结算后触发）——
+    let lastNotifyTs = 0
+    function fmtCost(n) {
+      const v = Number(n)
+      if (!isFinite(v) || v <= 0) return '0'
+      // 金额通常很小：保留 4 位小数并去掉尾 0（0.0123 / 0.005）
+      return v.toFixed(4).replace(/\.?0+$/, '')
+    }
+    function fmtInt(n) {
+      return String(Math.round(Number(n) || 0)).replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    }
+    function notifyTurnDone(agg) {
+      try {
+        const cfg = readSizeConfig() || {}
+        if (cfg.alertToastOn === false) return // 菜单「系统通知」关闭时不打扰
+        const now = Date.now()
+        // 限流：子代理/并行会话扎堆结束时 4s 内只发一条，避免通知刷屏
+        if (now - lastNotifyTs < 4000) return
+        lastNotifyTs = now
+        windowsToast('🐋 本轮任务已完成', '消耗 ¥' + fmtCost(agg.cost) + ' · ' + fmtInt(agg.tokens) + ' tokens')
+      } catch (err) {}
+    }
+    function windowsToast(title, body) {
+      // 仅 Windows 有意义，其他平台静默跳过。零外部依赖：优先 WinRT 原生
+      // 通知（进入 Windows 操作中心），失败自动降级为系统托盘气泡。
+      if (process.platform !== 'win32') return
+      try {
+        const ps = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+        const script = [
+          "$ErrorActionPreference = 'SilentlyContinue'",
+          'function esc([string]$s) { if ($null -eq $s) { return \'\' }; return [System.Security.SecurityElement]::Escape($s) }',
+          '$title = $env:DSHW_TOAST_TITLE',
+          '$body = $env:DSHW_TOAST_BODY',
+          '$xmlText = \'<?xml version="1.0" encoding="utf-8"?><toast><visual><binding template="ToastText02"><text id="1">\' + (esc $title) + \'</text><text id="2">\' + (esc $body) + \'</text></binding></visual></toast>\'',
+          '$ok = $false',
+          'try {',
+          '  [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null',
+          '  [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null',
+          '  $doc = New-Object Windows.Data.Xml.Dom.XmlDocument',
+          '  $doc.LoadXml($xmlText)',
+          '  $toast = New-Object Windows.UI.Notifications.ToastNotification $doc',
+          "  [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('dsh-whale-widget').Show($toast)",
+          '  $ok = $true',
+          '} catch {}',
+          'if (-not $ok) {',
+          '  try {',
+          '    Add-Type -AssemblyName System.Windows.Forms',
+          '    Add-Type -AssemblyName System.Drawing',
+          '    $n = New-Object System.Windows.Forms.NotifyIcon',
+          '    $n.Icon = [System.Drawing.SystemIcons]::Information',
+          '    $n.Visible = $true',
+          "    $n.BalloonTipIcon = 'Info'",
+          '    $n.BalloonTipTitle = $title',
+          '    $n.BalloonTipText = $body',
+          '    $n.ShowBalloonTip(8000)',
+          '    Start-Sleep -Milliseconds 900',
+          '    $n.Dispose()',
+          '  } catch {}',
+          '}',
+        ].join('\n')
+        const child = spawn(ps, ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script], {
+          env: { ...process.env, DSHW_TOAST_TITLE: String(title), DSHW_TOAST_BODY: String(body) },
+          windowsHide: true,
+          stdio: 'ignore',
+        })
+        child.on('error', () => {})
+      } catch (err) {}
+    }
+
     function finalizeTurn(sessionId) {
       const agg = turnAggs.get(sessionId)
       if (agg && agg.cost > 0) {
         lastTurn = { turn: agg.turn, amount: agg.cost, tokens: agg.tokens, ts: agg.lastTs }
         lastTurnSeq++
+        // 任务完成提醒：本轮会话结算 → 发 Windows 系统通知（菜单「系统通知」开关控制）
+        notifyTurnDone(agg)
       }
       turnAggs.delete(sessionId)
     }
@@ -1781,6 +1948,8 @@ function apply(ctx) {
               turnCostCloseMs: typeof parsed.turnCostCloseMs === 'number' ? parsed.turnCostCloseMs : 5000,
               scrollGapOn: parsed.scrollGapOn === true,
               scrollGapPx: typeof parsed.scrollGapPx === 'number' ? Math.round(parsed.scrollGapPx) : 17,
+              alertSoundOn: parsed.alertSoundOn !== false,
+              alertToastOn: parsed.alertToastOn !== false,
             }
           }
         } catch (err) {}
@@ -1788,7 +1957,7 @@ function apply(ctx) {
       return null
     }
 
-    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs, scrollGapOn, scrollGapPx) {
+    function writeSizeConfig(scale, sound, vol, soundSet, usageMode, peakMode, bubbleOn, turnCostOn, turnCostCloseMs, scrollGapOn, scrollGapPx, alertSoundOn, alertToastOn) {
       const um = normalizeUsageMode(usageMode)
       const pm = peakMode === 'liangwen' || peakMode === 'qiangqiang' ? peakMode : 'default'
       const bo = bubbleOn !== false
@@ -1796,6 +1965,8 @@ function apply(ctx) {
       const tcc = typeof turnCostCloseMs === 'number' ? (turnCostCloseMs > 0 ? turnCostCloseMs : 0) : 5000
       const sgo = scrollGapOn === true
       const sgp = typeof scrollGapPx === 'number' && scrollGapPx > 0 ? Math.round(scrollGapPx) : 0
+      const aso = alertSoundOn !== false
+      const ato = alertToastOn !== false
       const body = JSON.stringify({
         scale: scale,
         sound: sound !== false,
@@ -1808,6 +1979,8 @@ function apply(ctx) {
         turnCostCloseMs: tcc,
         scrollGapOn: sgo,
         scrollGapPx: sgp,
+        alertSoundOn: aso,
+        alertToastOn: ato,
         updatedAt: new Date().toISOString(),
       })
       for (const p of SIZE_FILE_CANDIDATES) {
@@ -1826,6 +1999,8 @@ function apply(ctx) {
             turnCostCloseMs: tcc,
             scrollGapOn: sgo,
             scrollGapPx: sgp,
+            alertSoundOn: aso,
+            alertToastOn: ato,
           }
         } catch (err) {}
       }
@@ -1937,7 +2112,7 @@ function apply(ctx) {
                 balanceCache = null
               }
             }
-            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs, parsed.scrollGapOn, parsed.scrollGapPx)
+            const result = writeSizeConfig(scale, parsed.sound !== false, parsed.vol, parsed.soundSet, parsed.usageMode, parsed.peakMode, parsed.bubbleOn, parsed.turnCostOn, parsed.turnCostCloseMs, parsed.scrollGapOn, parsed.scrollGapPx, parsed.alertSoundOn, parsed.alertToastOn)
             res.writeHead(result.ok ? 200 : 500, JSON_HEADERS)
             res.end(JSON.stringify(result))
           } catch (err) {
@@ -1991,6 +2166,15 @@ function apply(ctx) {
       handler: (req, res) => {
         const set = SOUND_SETS[soundSetFromUrl(req.url)] || SOUND_SETS.duck
         serveSound(req, res, set.release)
+      },
+    }))
+
+    disposers.push(ctx.webServer.register({
+      kind: 'exact',
+      path: '/dsh-whale/sound/done.mp3',
+      handler: (req, res) => {
+        // 自定义任务完成音：assets/done.mp3（或旧版绝对路径）存在才 200，否则 404
+        serveSound(req, res, DONE_SOUND_CANDIDATES)
       },
     }))
 


### PR DESCRIPTION
## 改动内容 / What changed

本轮会话（`turn/end` 结算，即每轮对话消耗统计的同一触发点）完成后：

**① 完成提示音（浏览器端）**
- 客户端检测到新的一轮结束即播放完成音：优先使用当前音效组（小黄鸭/音效1）；
- 新增自定义「完成音」支持：包内 `assets/done.mp3` 存在时单独播放（新路由 `/dsh-whale/sound/done.mp3`，文件缺失返回 404，前端自动回退到 press+release 两连音，不破坏旧行为、无需音效文件也能用）。

**② Windows 系统通知（宿主端）**
- 零新增依赖：WinRT 原生通知（进 Windows 操作中心），失败自动降级为系统托盘气泡；仅 Windows 生效，其他平台静默跳过；
- 4 秒限流：子代理/并行会话扎堆结束时不会刷屏。

**③ 菜单开关**
- 汉堡菜单新增「完成任务提醒」行：**音效 / 系统通知** 两个开关（默认开启），与既有挂件配置一并持久化（`.dshw-size.json`）。

## 背景 / Why
此前音效只绑定「点击鲸鱼」；本改动把音效与「每轮对话消耗结算」事件结合，让任务完成有声音与系统提醒，且两处可独立开关。

## 验证 / Testing
- `node --check` 通过；已在本机 DSH 热重载验证：
  - `/dsh-whale/sound/done.mp3` 无文件时 404，放置 mp3 后 200 `audio/mpeg`；
  - `size.json` GET 返回新增 `alertSoundOn/alertToastOn`；
  - 每轮结束后收到 Windows toast，菜单可关闭任一提醒。
- 说明：完成音遵循浏览器自动播放策略（页面需先有过交互，与点击音效解锁条件一致）。

English: When a conversation round finishes (the same `turn/end` hook used by the existing per-round cost stats):
1. Client plays a completion sound from the selected sound set, or a custom single-note `assets/done.mp3` when present (new `/dsh-whale/sound/done.mp3` route; 404 silently falls back to the press+release pair — no behavior change and no sound file required).
2. Host sends a Windows toast — WinRT native (Action Center) with a tray-balloon fallback; Windows only, no-op elsewhere; throttled to one per 4 s so sub-agent bursts don't spam.
3. New hamburger-menu row 完成任务提醒 with two persisted toggles: 音效 (sound) and 系统通知 (toast).

No new dependencies; route/persisted-config structure unchanged. Verified locally via hot reload (`node --check`, route probes, live toast).