### PR TITLE
优化消耗气泡交互与余额刷新逻辑，并修正计费单价与 token 口径

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,13 +64,19 @@ const RUA_GIF_CANDIDATES = [
 ]
 // DeepSeek CNY prices per million tokens: [空闲时段价, 高峰时段价].
 // 高峰时段：工作日 9:00–12:00 和 14:00–18:00（北京时间）；2026-08-23 起周末全天谷价。
+// 2026-09-10 中午起 Flash 系列执行峰谷新价：缓存命中(谷) 0.02 元（"回到 2 分钱"）、
+// 输出(谷) 4 元/百万；命中档降 60%（0.05→0.02，峰 0.1→0.04）。输入未命中(miss) 与
+//   空闲时段 缓存命中 0.02 元、缓存未命中 1.0 元、输出 4.0 元 / 百万 token；
+//   高峰时段各项均为闲时的 2 倍。缓存命中与未命中价差 50 倍（0.02 : 1.0）。
 // Adjust here if DeepSeek changes pricing.
 const PEAK_HOURS = [
   [9, 12],
   [14, 18],
 ]
-const BASE_PRICE = { hit: [0.05, 0.1], miss: [1.5, 3.0], out: [4.5, 9.0] }
-// deepseek-v4-pro 为 flash 的 3 倍价（官方 2026-08-17 生效）；vision-exp 与 flash 同价
+const BASE_PRICE = { hit: [0.02, 0.04], miss: [1.0, 2.0], out: [4.0, 8.0] }
+// deepseek-v4-pro 为 flash 的 3 倍价（官方 2026-08-17 生效）；vision-exp 与 flash 同价。
+// 注意：deepseek-v4.1-* 不命中 v4-flash/v4-pro 子串，会落到 _default（= flash 价），
+// 因此 V4.1 Flash 按 flash 价正确；若将来有 V4.1 Pro 需在此显式加 PRO_PRICE 条目。
 const PRO_PRICE = { hit: [0.15, 0.3], miss: [4.5, 9.0], out: [13.5, 27.0] }
 const PRICING = {
   'deepseek-v4-flash-vision-exp': BASE_PRICE,
@@ -440,6 +446,7 @@ var animDelayTimer = null
 var drag = null
 var shown = null
 var animId = null
+var clickDelay = 0
 var bubbleShown = false
 var bubbleTimer = null
 var bubbleRandomActive = false
@@ -616,7 +623,7 @@ function hideBubble() {
 
 // —— 每轮对话消耗金额泡泡 ——
 var costBubbleTimer = null
-function showCostBubble(amount) {
+function showCostBubble(amount, tokens) {
   if (!bubbleOn || !turnCostOn) return
   if (costBubbleTimer) { clearTimeout(costBubbleTimer); costBubbleTimer = null }
   if (bubbleTimer) { clearTimeout(bubbleTimer); bubbleTimer = null }
@@ -640,9 +647,16 @@ function showCostBubble(amount) {
   amountEl.className = 'dshwv-amount'
   amountEl.textContent = '¥ ' + (isFinite(amount) ? Number(amount).toFixed(2) : '--')
   amountEl.style.color = '#e0433f'
-  hintEl.style.display = 'none'
-  hintEl.textContent = ''
-  hintEl.style.color = ''
+  // 第三行：本轮 token 总量（与 DSH 会话界面「本轮用量」同口径）
+  if (isFinite(tokens) && tokens > 0) {
+    hintEl.style.display = ''
+    hintEl.textContent = Number(tokens).toLocaleString('en-US') + ' tok'
+    hintEl.style.color = ''
+  } else {
+    hintEl.style.display = 'none'
+    hintEl.textContent = ''
+    hintEl.style.color = ''
+  }
   textBox.style.transition = ''
   textBox.style.opacity = ''
   bubbleBox.classList.add('dshwv-bubble-open')
@@ -777,35 +791,36 @@ function refresh(manual) {
       if (data && data.ok) {
         var nb = Number(data.totalBalance)
         var nc = String(data.currency || 'CNY')
-        var changed = state.balance !== null && (nb !== state.balance || nc !== state.currency)
         var currencyChanged = state.currency !== null && nc !== state.currency
         state.balance = nb
         state.currency = nc
         state.message = ''
         state.todayUsage = data.todayUsage !== undefined ? data.todayUsage : null
         state.isPeak = !!data.isPeak
-        if (changed && !currencyChanged) {
-          if (!manual) {
-            showBubble()
-            state.status = 'changing'
-            // balance-change bubble: wait 0.3s after it floats out, then roll the number
-            if (animDelayTimer) clearTimeout(animDelayTimer)
-            animDelayTimer = setTimeout(function () {
-              animDelayTimer = null
-              animateAmount(shown, nb, nc, ANIM_MS)
-            }, 300)
-            if (settleTimer) clearTimeout(settleTimer)
-            settleTimer = setTimeout(function () {
-              settleTimer = null
-              if (state.status === 'changing') { state.status = 'ok'; render() }
-            }, CHANGE_MS + 300)
-          } else {
-            animateAmount(shown, nb, nc, ANIM_MS)
-            state.status = 'ok'
-            render()
-          }
-        } else {
+        if (currencyChanged) {
+          // 币种切换：直接同步显示，不滚动
           if (animId === null) shown = nb
+          state.status = 'ok'
+          render()
+        } else if (manual) {
+          // 点击刷新：显示值与最新值不同则滚动（气泡刚展开延时、已展开立即）
+          if (shown !== null && isFinite(shown) && shown !== nb) {
+            if (clickDelay > 0) {
+              if (animDelayTimer) clearTimeout(animDelayTimer)
+              animDelayTimer = setTimeout(function () {
+                animDelayTimer = null
+                animateAmount(shown, nb, nc, ANIM_MS)
+              }, clickDelay)
+            } else {
+              animateAmount(shown, nb, nc, ANIM_MS)
+            }
+          }
+          state.status = 'ok'
+          render()
+          clickDelay = 0
+        } else {
+          // 后台刷新：不弹不滚，只更新余额；shown 保持旧值（仅首次加载才同步）
+          if (shown === null) shown = nb
           state.status = 'ok'
           render()
         }
@@ -1230,7 +1245,14 @@ function endDrag(e, clickAllowed) {
   pressUp()
   root.classList.remove('dshwv-dragging')
   setWidgetCursor(isWhaleHit(e) ? 'grab' : '')
-  if (clickAllowed && !drag.moved) { showBubble(); refresh(true); return }
+  if (clickAllowed && !drag.moved) {
+    var alreadyOpen = bubbleShown
+    showBubble()
+    // 气泡刚展开则延时等文字淡入（约 0.55s），已展开则立即滚动
+    clickDelay = alreadyOpen ? 0 : 550
+    refresh(true)
+    return
+  }
   var dx = e.clientX - drag.startX
   var dy = e.clientY - drag.startY
   var left = clamp(drag.origLeft + dx, 0, Math.max(0, drag.vp.w - drag.w))
@@ -1403,7 +1425,7 @@ function pollLastTurn() {
         if (d.seq > lastCostSeq) {
           lastCostSeq = d.seq
           if (d.turn !== null && d.amount !== null) {
-            showCostBubble(Number(d.amount))
+            showCostBubble(Number(d.amount), Number(d.tokens))
           }
         }
       })
@@ -1460,15 +1482,22 @@ function apply(ctx) {
         }
         const input = Number(usage.inputTokens) || 0
         const cache = Number(usage.cacheReadTokens) || 0
+        // outputTokens 已包含 reasoningTokens（DeepSeek 的 completion_tokens 含推理 token），
+        // 因此不再单独加 reasoning，否则推理 token 会按输出价被重复计费。
         const output = Number(usage.outputTokens) || 0
-        const reasoning = Number(usage.reasoningTokens) || 0
-        agg.tokens += input + cache + output + reasoning
-        // 定价换算（CNY/百万 token；缓存命中=输入价，其余按各自档位）
+        // totalTokens 是适配器给出的权威总量（= input + cacheRead + output，已逐帧核对真实数据），
+        // 优先用它以便与 DSH 会话界面「本轮用量」口径完全一致；缺失时回退到求和。
+        const total = Number(usage.totalTokens)
+        agg.tokens += Number.isFinite(total) && total > 0 ? total : input + cache + output
+        // 定价换算（CNY/百万 token；缓存命中=hit 价，未命中输入=miss 价，输出=out 价）
         const model = d.message && d.message.source ? d.message.source.model : ''
         const p = priceFor(model)
-        const off = isPeakTime(Math.floor(Date.now() / 1000)) ? 1 : 0
-        agg.cost += (cache / 1e6) * p.hit[off] + (input / 1e6) * p.miss[off] + ((output + reasoning) / 1e6) * p.out[off]
-        agg.lastTs = Date.now()
+        // 用事件自带的时间戳而非处理时刻：它就是写入会话日志的同一个值，
+        // 因此同一轮无论何时重算都得到相同金额，也不受事件循环延迟影响。
+        const atMs = typeof event.time === 'number' ? event.time : Date.now()
+        const off = isPeakTime(Math.floor(atMs / 1000)) ? 1 : 0
+        agg.cost += (cache / 1e6) * p.hit[off] + (input / 1e6) * p.miss[off] + (output / 1e6) * p.out[off]
+        agg.lastTs = atMs
       } catch (err) {}
     }
 


### PR DESCRIPTION
## 改动内容

### 计费修正

- **修复推理 token 重复计费。** DeepSeek 的 `completion_tokens` 已包含推理 token，原先又单独累加了 `reasoningTokens`，导致推理部分按输出价被重复计费。

- **更新 Flash 系列定价为 2026-09-10 12:00 起执行的峰谷新价**（依据 DeepSeek 开放平台公告）：
  - 空闲时段：缓存命中 0.02、缓存未命中 1.0、输出 4.0 元/百万 token
  - 高峰时段（工作日 9:00-12:00、14:00-18:00）：各项为闲时 2 倍
  - 原先未命中档写的是 1.5，是按「高峰为闲时 2 倍」推断的，高估 50%

- **token 总量优先取适配器给出的 `usage.totalTokens`**，缺失时回退 `input + cacheRead + output`。已逐帧核对 45 个真实步骤：`totalTokens` 恒等于三者之和，且与 DSH 会话界面「本轮用量」完全一致。

- **峰谷判定改用事件自带的 `event.time`**，而非处理时刻 `Date.now()`。事件时间戳就是写入会话日志的同一个值，因此同一轮无论何时重算都得到相同金额，也不受事件循环延迟影响。平台 API 路径（`isPeakTime(b.time)`）本来就是这么做的，这次让事件路径与之一致。

- **消耗气泡新增第三行，显示本轮 token 总数。** `/dsh-whale/last-turn.json` 端点早已返回 `tokens` 字段，只是前端拿到后未使用。

### 余额刷新交互

- **重构 `refresh()` 的余额刷新逻辑**，区分三种情况分别处理：
  - 币种切换：直接同步显示新值，不做滚动动画。
  - 手动刷新（点击组件）：显示值与最新值不同时，播放数字滚动动画。
  - 后台自动刷新：只更新状态，不弹气泡、不滚动数字；`shown` 保持旧值，仅在首次加载时同步。

- **新增 `clickDelay` 控制点击后的滚动时机**：气泡刚展开时延迟约 550ms 等文字淡入完成再滚动数字；气泡已经展开时立即滚动，不延迟。

## 影响

缓存命中 99.9% 的轮次，旧价只高估约 1%；但缓存冷启动（切模型、改 system prompt、大上下文变更）时未缓存输入占比高，旧价会高估 25–30%。实测同一轮：旧 ¥0.1988 / 新 ¥0.1430。

## 涉及文件

- `lib/index.js`

## 测试方式

**计费**

1. 发一句话，确认消耗气泡第三行显示本轮 token 总数。
2. 与悬停卡片「本轮用量」对比，两者应完全一致（实测 9,651 = 9,651）。
3. 切一次模型制造缓存冷启动，对比金额变化幅度。
4. 「自动关闭」填 0 → 气泡保持展开、点击关闭；填 N → N 秒后自动关闭。

**交互**

5. 点击组件刷新余额 → 数字在淡入后（约 0.55s）开始滚动。
6. 等待后台轮询刷新 → 数字不滚动、气泡不弹出。
7. 切换币种 → 数值立即更新，没有滚动动画。
